### PR TITLE
Release 1.2.0

### DIFF
--- a/Testura.Android.PageObjectCreator.sln
+++ b/Testura.Android.PageObjectCreator.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.26127.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Testura.Android.PageObjectCreator", "src\Testura.Android.PageObjectCreator\Testura.Android.PageObjectCreator.csproj", "{1B800835-5BE3-485E-A622-4D8225C8DD9E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Testura.Android.PageObjectCreator.Tests", "src\Testura.Android.PageObjectCreator.Tests\Testura.Android.PageObjectCreator.Tests.csproj", "{9D8231F0-73FE-4610-B4AB-A642D9AAA5AD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{1B800835-5BE3-485E-A622-4D8225C8DD9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1B800835-5BE3-485E-A622-4D8225C8DD9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1B800835-5BE3-485E-A622-4D8225C8DD9E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9D8231F0-73FE-4610-B4AB-A642D9AAA5AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D8231F0-73FE-4610-B4AB-A642D9AAA5AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9D8231F0-73FE-4610-B4AB-A642D9AAA5AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9D8231F0-73FE-4610-B4AB-A642D9AAA5AD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Testura.Android.PageObjectCreator.Tests/Dialogs/AboutDialogTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Dialogs/AboutDialogTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Dialogs
     [TestFixture]
     public class AboutDialogTests
     {
-        private AboutDialog aboutDialog;
+        private AboutDialog _aboutDialog;
 
         [SetUp]
         public void SetUp()
         {
-            aboutDialog = new AboutDialog();
+            _aboutDialog = new AboutDialog();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Dialogs/AboutDialogTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Dialogs/AboutDialogTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Dialogs;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Dialogs
+{
+    [TestFixture]
+    public class AboutDialogTests
+    {
+        private AboutDialog aboutDialog;
+
+        [SetUp]
+        public void SetUp()
+        {
+            aboutDialog = new AboutDialog();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Dialogs/ErrorDialogTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Dialogs/ErrorDialogTests.cs
@@ -1,0 +1,18 @@
+using Testura.Android.PageObjectCreator.Dialogs;
+using NUnit.Framework;
+using System;
+
+namespace Testura.Android.PageObjectCreator.Tests.Dialogs
+{
+    [TestFixture]
+    public class ErrorDialogTests
+    {
+        private ErrorDialog errorDialog;
+
+        [SetUp]
+        public void SetUp()
+        {
+            errorDialog = new ErrorDialog(string.Empty);
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Dialogs/ErrorDialogTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Dialogs/ErrorDialogTests.cs
@@ -7,12 +7,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Dialogs
     [TestFixture]
     public class ErrorDialogTests
     {
-        private ErrorDialog errorDialog;
+        private ErrorDialog _errorDialog;
 
         [SetUp]
         public void SetUp()
         {
-            errorDialog = new ErrorDialog(string.Empty);
+            _errorDialog = new ErrorDialog(string.Empty);
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Dialogs/NameDialogTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Dialogs/NameDialogTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Dialogs;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Dialogs
+{
+    [TestFixture]
+    public class NameDialogTests
+    {
+        private NameDialog nameDialog;
+
+        [SetUp]
+        public void SetUp()
+        {
+            nameDialog = new NameDialog();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Dialogs/NameDialogTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Dialogs/NameDialogTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Dialogs
     [TestFixture]
     public class NameDialogTests
     {
-        private NameDialog nameDialog;
+        private NameDialog _nameDialog;
 
         [SetUp]
         public void SetUp()
         {
-            nameDialog = new NameDialog();
+            _nameDialog = new NameDialog();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Dialogs/WithDialogTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Dialogs/WithDialogTests.cs
@@ -1,5 +1,7 @@
+using System.Collections.Generic;
 using Testura.Android.PageObjectCreator.Dialogs;
 using NUnit.Framework;
+using Testura.Android.Device.Ui.Nodes.Data;
 using Testura.Android.PageObjectCreator.Models;
 
 namespace Testura.Android.PageObjectCreator.Tests.Dialogs
@@ -13,7 +15,7 @@ namespace Testura.Android.PageObjectCreator.Tests.Dialogs
         [SetUp]
         public void SetUp()
         {
-            withDialog = new WithDialog(null);
+            withDialog = new WithDialog(null, new List<Node>());
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Dialogs/WithDialogTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Dialogs/WithDialogTests.cs
@@ -9,13 +9,14 @@ namespace Testura.Android.PageObjectCreator.Tests.Dialogs
     [TestFixture]
     public class WithDialogTests
     {
-        private UiObjectInfo uiObjectInfo;
-        private WithDialog withDialog;
+        private UiObjectInfo _uiObjectInfo;
+        private WithDialog _withDialog;
 
         [SetUp]
         public void SetUp()
         {
-            withDialog = new WithDialog(null, new List<Node>());
+            _uiObjectInfo = new UiObjectInfo();
+            _withDialog = new WithDialog(_uiObjectInfo, new List<Node>());
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Dialogs/WithDialogTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Dialogs/WithDialogTests.cs
@@ -1,0 +1,19 @@
+using Testura.Android.PageObjectCreator.Dialogs;
+using NUnit.Framework;
+using Testura.Android.PageObjectCreator.Models;
+
+namespace Testura.Android.PageObjectCreator.Tests.Dialogs
+{
+    [TestFixture]
+    public class WithDialogTests
+    {
+        private UiObjectInfo uiObjectInfo;
+        private WithDialog withDialog;
+
+        [SetUp]
+        public void SetUp()
+        {
+            withDialog = new WithDialog(null);
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/AndroidDumpInfoTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/AndroidDumpInfoTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Models
     [TestFixture]
     public class AndroidDumpInfoTests
     {
-        private AndroidDumpInfo androidDumpInfo;
+        private AndroidDumpInfo _androidDumpInfo;
 
         [SetUp]
         public void SetUp()
         {
-            androidDumpInfo = new AndroidDumpInfo();
+            _androidDumpInfo = new AndroidDumpInfo();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/AndroidDumpInfoTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/AndroidDumpInfoTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Models;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Models
+{
+    [TestFixture]
+    public class AndroidDumpInfoTests
+    {
+        private AndroidDumpInfo androidDumpInfo;
+
+        [SetUp]
+        public void SetUp()
+        {
+            androidDumpInfo = new AndroidDumpInfo();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/AttributeTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/AttributeTests.cs
@@ -1,0 +1,17 @@
+using NUnit.Framework;
+using Attribute = Testura.Android.PageObjectCreator.Models.Attribute;
+
+namespace Testura.Android.PageObjectCreator.Tests.Models
+{
+    [TestFixture]
+    public class AttributeTests
+    {
+        private Attribute attribute;
+
+        [SetUp]
+        public void SetUp()
+        {
+            attribute = new Attribute(string.Empty, string.Empty);
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/AttributeTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/AttributeTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Models
     [TestFixture]
     public class AttributeTests
     {
-        private Attribute attribute;
+        private Attribute _attribute;
 
         [SetUp]
         public void SetUp()
         {
-            attribute = new Attribute(string.Empty, string.Empty);
+            _attribute = new Attribute(string.Empty, string.Empty);
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/ImageScaleTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/ImageScaleTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Models
     [TestFixture]
     public class ImageScaleTests
     {
-        private ImageScale imageScale;
+        private ImageScale _imageScale;
 
         [SetUp]
         public void SetUp()
         {
-            imageScale = new ImageScale();
+            _imageScale = new ImageScale();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/ImageScaleTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/ImageScaleTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Models;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Models
+{
+    [TestFixture]
+    public class ImageScaleTests
+    {
+        private ImageScale imageScale;
+
+        [SetUp]
+        public void SetUp()
+        {
+            imageScale = new ImageScale();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/AddNodeMessageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/AddNodeMessageTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Models.Messages;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
+{
+    [TestFixture]
+    public class AddNodeMessageTests
+    {
+        private AddNodeMessage addNodeMessage;
+
+        [SetUp]
+        public void SetUp()
+        {
+            addNodeMessage = new AddNodeMessage();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/AddNodeMessageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/AddNodeMessageTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
     [TestFixture]
     public class AddNodeMessageTests
     {
-        private AddNodeMessage addNodeMessage;
+        private AddNodeMessage _addNodeMessage;
 
         [SetUp]
         public void SetUp()
         {
-            addNodeMessage = new AddNodeMessage();
+            _addNodeMessage = new AddNodeMessage();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/AddUiObjectInfoMessageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/AddUiObjectInfoMessageTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Models.Messages;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
+{
+    [TestFixture]
+    public class AddUiObjectInfoMessageTests
+    {
+        private AddUiObjectInfoMessage addUiObjectInfoMessage;
+
+        [SetUp]
+        public void SetUp()
+        {
+            addUiObjectInfoMessage = new AddUiObjectInfoMessage();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/AddUiObjectInfoMessageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/AddUiObjectInfoMessageTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
     [TestFixture]
     public class AddUiObjectInfoMessageTests
     {
-        private AddUiObjectInfoMessage addUiObjectInfoMessage;
+        private AddUiObjectInfoMessage _addUiObjectInfoMessage;
 
         [SetUp]
         public void SetUp()
         {
-            addUiObjectInfoMessage = new AddUiObjectInfoMessage();
+            _addUiObjectInfoMessage = new AddUiObjectInfoMessage();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/DeviceAvailableMessageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/DeviceAvailableMessageTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
     [TestFixture]
     public class DeviceAvailableMessageTests
     {
-        private DeviceAvailableMessage deviceAvailableMessage;
+        private DeviceAvailableMessage _deviceAvailableMessage;
 
         [SetUp]
         public void SetUp()
         {
-            deviceAvailableMessage = new DeviceAvailableMessage();
+            _deviceAvailableMessage = new DeviceAvailableMessage();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/DeviceAvailableMessageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/DeviceAvailableMessageTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Models.Messages;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
+{
+    [TestFixture]
+    public class DeviceAvailableMessageTests
+    {
+        private DeviceAvailableMessage deviceAvailableMessage;
+
+        [SetUp]
+        public void SetUp()
+        {
+            deviceAvailableMessage = new DeviceAvailableMessage();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/DumpMessageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/DumpMessageTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
     [TestFixture]
     public class DumpMessageTests
     {
-        private DumpMessage dumpMessage;
+        private DumpMessage _dumpMessage;
 
         [SetUp]
         public void SetUp()
         {
-            dumpMessage = new DumpMessage();
+            _dumpMessage = new DumpMessage();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/DumpMessageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/DumpMessageTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Models.Messages;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
+{
+    [TestFixture]
+    public class DumpMessageTests
+    {
+        private DumpMessage dumpMessage;
+
+        [SetUp]
+        public void SetUp()
+        {
+            dumpMessage = new DumpMessage();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/PageObjectChangedMessageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/PageObjectChangedMessageTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
     [TestFixture]
     public class PageObjectChangedMessageTests
     {
-        private PageObjectChangedMessage pageObjectChangedMessage;
+        private PageObjectChangedMessage _pageObjectChangedMessage;
 
         [SetUp]
         public void SetUp()
         {
-            pageObjectChangedMessage = new PageObjectChangedMessage();
+            _pageObjectChangedMessage = new PageObjectChangedMessage();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/PageObjectChangedMessageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/PageObjectChangedMessageTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Models.Messages;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
+{
+    [TestFixture]
+    public class PageObjectChangedMessageTests
+    {
+        private PageObjectChangedMessage pageObjectChangedMessage;
+
+        [SetUp]
+        public void SetUp()
+        {
+            pageObjectChangedMessage = new PageObjectChangedMessage();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/RequestDumpMessageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/RequestDumpMessageTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
     [TestFixture]
     public class RequestDumpMessageTests
     {
-        private RequestDumpMessage requestDumpMessage;
+        private RequestDumpMessage _requestDumpMessage;
 
         [SetUp]
         public void SetUp()
         {
-            requestDumpMessage = new RequestDumpMessage();
+            _requestDumpMessage = new RequestDumpMessage();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/RequestDumpMessageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/RequestDumpMessageTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Models.Messages;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
+{
+    [TestFixture]
+    public class RequestDumpMessageTests
+    {
+        private RequestDumpMessage requestDumpMessage;
+
+        [SetUp]
+        public void SetUp()
+        {
+            requestDumpMessage = new RequestDumpMessage();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/RequestRefreshDeviceListCommandTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/RequestRefreshDeviceListCommandTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Models.Messages;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
+{
+    [TestFixture]
+    public class RequestRefreshDeviceListCommandTests
+    {
+        private RequestRefreshDeviceListCommand requestRefreshDeviceListCommand;
+
+        [SetUp]
+        public void SetUp()
+        {
+            requestRefreshDeviceListCommand = new RequestRefreshDeviceListCommand();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/RequestRefreshDeviceListCommandTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/RequestRefreshDeviceListCommandTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
     [TestFixture]
     public class RequestRefreshDeviceListCommandTests
     {
-        private RequestRefreshDeviceListCommand requestRefreshDeviceListCommand;
+        private RequestRefreshDeviceListCommand _requestRefreshDeviceListCommand;
 
         [SetUp]
         public void SetUp()
         {
-            requestRefreshDeviceListCommand = new RequestRefreshDeviceListCommand();
+            _requestRefreshDeviceListCommand = new RequestRefreshDeviceListCommand();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/SelectedDeviceChangedMessageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/SelectedDeviceChangedMessageTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
     [TestFixture]
     public class SelectedDeviceChangedMessageTests
     {
-        private SelectedDeviceChangedMessage selectedDeviceChangedMessage;
+        private SelectedDeviceChangedMessage _selectedDeviceChangedMessage;
 
         [SetUp]
         public void SetUp()
         {
-            selectedDeviceChangedMessage = new SelectedDeviceChangedMessage();
+            _selectedDeviceChangedMessage = new SelectedDeviceChangedMessage();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/SelectedDeviceChangedMessageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/SelectedDeviceChangedMessageTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Models.Messages;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
+{
+    [TestFixture]
+    public class SelectedDeviceChangedMessageTests
+    {
+        private SelectedDeviceChangedMessage selectedDeviceChangedMessage;
+
+        [SetUp]
+        public void SetUp()
+        {
+            selectedDeviceChangedMessage = new SelectedDeviceChangedMessage();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/SelectedHierarchyNodeMesssageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/SelectedHierarchyNodeMesssageTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Models.Messages;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
+{
+    [TestFixture]
+    public class SelectedHierarchyNodeMesssageTests
+    {
+        private SelectedHierarchyNodeMesssage selectedHierarchyNodeMesssage;
+
+        [SetUp]
+        public void SetUp()
+        {
+            selectedHierarchyNodeMesssage = new SelectedHierarchyNodeMesssage();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/SelectedHierarchyNodeMesssageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/SelectedHierarchyNodeMesssageTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
     [TestFixture]
     public class SelectedHierarchyNodeMesssageTests
     {
-        private SelectedHierarchyNodeMesssage selectedHierarchyNodeMesssage;
+        private SelectedHierarchyNodeMesssage _selectedHierarchyNodeMesssage;
 
         [SetUp]
         public void SetUp()
         {
-            selectedHierarchyNodeMesssage = new SelectedHierarchyNodeMesssage();
+            _selectedHierarchyNodeMesssage = new SelectedHierarchyNodeMesssage();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/ShowNodeDetailsMessageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/ShowNodeDetailsMessageTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
     [TestFixture]
     public class ShowNodeDetailsMessageTests
     {
-        private ShowNodeDetailsMessage showNodeDetailsMessage;
+        private ShowNodeDetailsMessage _showNodeDetailsMessage;
 
         [SetUp]
         public void SetUp()
         {
-            showNodeDetailsMessage = new ShowNodeDetailsMessage();
+            _showNodeDetailsMessage = new ShowNodeDetailsMessage();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/ShowNodeDetailsMessageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/ShowNodeDetailsMessageTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Models.Messages;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
+{
+    [TestFixture]
+    public class ShowNodeDetailsMessageTests
+    {
+        private ShowNodeDetailsMessage showNodeDetailsMessage;
+
+        [SetUp]
+        public void SetUp()
+        {
+            showNodeDetailsMessage = new ShowNodeDetailsMessage();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/StartedDumpScreenMessageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/StartedDumpScreenMessageTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Models.Messages;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
+{
+    [TestFixture]
+    public class StartedDumpScreenMessageTests
+    {
+        private StartedDumpScreenMessage startedDumpScreenMessage;
+
+        [SetUp]
+        public void SetUp()
+        {
+            startedDumpScreenMessage = new StartedDumpScreenMessage();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/StartedDumpScreenMessageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/StartedDumpScreenMessageTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
     [TestFixture]
     public class StartedDumpScreenMessageTests
     {
-        private StartedDumpScreenMessage startedDumpScreenMessage;
+        private StartedDumpScreenMessage _startedDumpScreenMessage;
 
         [SetUp]
         public void SetUp()
         {
-            startedDumpScreenMessage = new StartedDumpScreenMessage();
+            _startedDumpScreenMessage = new StartedDumpScreenMessage();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/StoppedDumpScreenMessageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/StoppedDumpScreenMessageTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Models.Messages;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
+{
+    [TestFixture]
+    public class StoppedDumpScreenMessageTests
+    {
+        private StoppedDumpScreenMessage stoppedDumpScreenMessage;
+
+        [SetUp]
+        public void SetUp()
+        {
+            stoppedDumpScreenMessage = new StoppedDumpScreenMessage();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/StoppedDumpScreenMessageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/StoppedDumpScreenMessageTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
     [TestFixture]
     public class StoppedDumpScreenMessageTests
     {
-        private StoppedDumpScreenMessage stoppedDumpScreenMessage;
+        private StoppedDumpScreenMessage _stoppedDumpScreenMessage;
 
         [SetUp]
         public void SetUp()
         {
-            stoppedDumpScreenMessage = new StoppedDumpScreenMessage();
+            _stoppedDumpScreenMessage = new StoppedDumpScreenMessage();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/UiObjectInfoRemovedMessageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/UiObjectInfoRemovedMessageTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Models.Messages;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
+{
+    [TestFixture]
+    public class UiObjectInfoRemovedMessageTests
+    {
+        private UiObjectInfoRemovedMessage uiObjectInfoRemovedMessage;
+
+        [SetUp]
+        public void SetUp()
+        {
+            uiObjectInfoRemovedMessage = new UiObjectInfoRemovedMessage();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/UiObjectInfoRemovedMessageTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/Messages/UiObjectInfoRemovedMessageTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Models.Messages
     [TestFixture]
     public class UiObjectInfoRemovedMessageTests
     {
-        private UiObjectInfoRemovedMessage uiObjectInfoRemovedMessage;
+        private UiObjectInfoRemovedMessage _uiObjectInfoRemovedMessage;
 
         [SetUp]
         public void SetUp()
         {
-            uiObjectInfoRemovedMessage = new UiObjectInfoRemovedMessage();
+            _uiObjectInfoRemovedMessage = new UiObjectInfoRemovedMessage();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/PageObjectTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/PageObjectTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Models;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Models
+{
+    [TestFixture]
+    public class PageObjectTests
+    {
+        private PageObject pageObject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            pageObject = new PageObject();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/PageObjectTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/PageObjectTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Models
     [TestFixture]
     public class PageObjectTests
     {
-        private PageObject pageObject;
+        private PageObject _pageObject;
 
         [SetUp]
         public void SetUp()
         {
-            pageObject = new PageObject();
+            _pageObject = new PageObject();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/UiObjectInfoTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/UiObjectInfoTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Models
     [TestFixture]
     public class UiObjectInfoTests
     {
-        private UiObjectInfo uiObjectInfo;
+        private UiObjectInfo _uiObjectInfo;
 
         [SetUp]
         public void SetUp()
         {
-            uiObjectInfo = new UiObjectInfo();
+            _uiObjectInfo = new UiObjectInfo();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Models/UiObjectInfoTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Models/UiObjectInfoTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Models;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Models
+{
+    [TestFixture]
+    public class UiObjectInfoTests
+    {
+        private UiObjectInfo uiObjectInfo;
+
+        [SetUp]
+        public void SetUp()
+        {
+            uiObjectInfo = new UiObjectInfo();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Properties/AssemblyInfo.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Testura.Android.PageObjectCreator.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Testura.Android.PageObjectCreator.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("9d8231f0-73fe-4610-b4ab-a642d9aaa5ad")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Testura.Android.PageObjectCreator.Tests/Services/CodeServiceTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Services/CodeServiceTests.cs
@@ -1,0 +1,136 @@
+﻿using System.Collections.Generic;
+using System.Xml.Linq;
+using NUnit.Framework;
+using Testura.Android.Device.Ui.Nodes.Data;
+using Testura.Android.PageObjectCreator.Models;
+using Testura.Android.PageObjectCreator.Services;
+using Testura.Android.Util;
+
+namespace Testura.Android.PageObjectCreator.Tests.Services
+{
+    [TestFixture]
+    public class CodeServiceTests
+    {
+        private ICodeService _codeService;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _codeService = new CodeService();
+        }
+
+        [Test]
+        public void GeneratePageObject_WhenHavingUiObjectWithTwoAttributes_ShouldGenerateCorrectAssignStatement()
+        {
+            var pageObjectInfo = new UiObjectInfo
+            {
+                Name = "myObject",
+                Node = new Node(new XElement("node", new XAttribute("class", "myClass"), new XAttribute("resource-id", "myResourceId")), null),
+                FindWith = new List<AttributeTags>
+                {
+                    AttributeTags.Class,
+                    AttributeTags.ResourceId
+                }
+            };
+
+            var code = _codeService.GeneratePageObject("test", "test", new List<UiObjectInfo> {pageObjectInfo});
+            Assert.IsTrue(code.Contains("CreateUiObject(With.Class(\"myClass\"), With.ResourceId(\"myResourceId\"));"));
+        }
+
+        [Test]
+        public void GeneratePageObject_WhenHavingUiObjectWithOptimalThatJustHaveAttributes_ShouldGenerateCorrectAssignStatement()
+        {
+            var pageObjectInfo = new UiObjectInfo
+            {
+                Name = "myObject",
+                Node = new Node(new XElement("node", new XAttribute("class", "myClass"), new XAttribute("resource-id", "myResourceId")), null),
+                Optimal = new OptimalWith { Withs = new List<AttributeTags>
+                {
+                    AttributeTags.Class,
+                    AttributeTags.ResourceId
+                }
+                }
+            };
+
+            var code = _codeService.GeneratePageObject("test", "test", new List<UiObjectInfo> { pageObjectInfo });
+            Assert.IsTrue(code.Contains("CreateUiObject(With.Class(\"myClass\"), With.ResourceId(\"myResourceId\"));"));
+        }
+
+        [Test]
+        public void GeneratePageObject_WhenHavingUiObjectWithOptimalThatHaveParent_ShouldGenerateCorrectAssignStatement()
+        {
+            var parentNode = new Node(new XElement("node", new XAttribute("class", "myClass"), new XAttribute("package", "package")), null);
+            var mainNode = new Node(new XElement("node", new XAttribute("class", "myClass"), new XAttribute("resource-id", "myResourceId")), parentNode);
+            
+
+            var pageObjectInfo = new UiObjectInfo
+            {
+                Name = "myObject",
+                Node = new Node(new XElement("node", new XAttribute("class", "myClass"), new XAttribute("resource-id", "myResourceId")), null),
+                Optimal = new OptimalWith
+                {
+                    Node = mainNode,
+                    Withs = new List<AttributeTags>
+                {
+                    AttributeTags.Class,
+                    AttributeTags.ResourceId
+                },
+                    Parent = new OptimalWith
+                    {
+                        Node = parentNode,
+                        Withs = new List<AttributeTags>
+                        {
+                            AttributeTags.Package
+                        }
+                    }
+                }
+            };
+
+            var code = _codeService.GeneratePageObject("test", "test", new List<UiObjectInfo> { pageObjectInfo });
+            Assert.IsTrue(code.Contains("CreateUiObject(With.Class(\"myClass\"), With.ResourceId(\"myResourceId\"));"));
+        }
+
+        [Test]
+        public void GeneratePageObject_WhenHavingUiObjectWithOptimalThatHaveTwoParent_ShouldGenerateCorrectAssignStatement()
+        {
+            var superParentNode = new Node(new XElement("node", new XAttribute("class", "oldi"), new XAttribute("package", "package")), null);
+            var parentNode = new Node(new XElement("node", new XAttribute("class", "myClass"), new XAttribute("package", "package")), superParentNode);
+            var mainNode = new Node(new XElement("node", new XAttribute("class", "myClass"), new XAttribute("resource-id", "myResourceId")), parentNode);
+
+
+            var pageObjectInfo = new UiObjectInfo
+            {
+                Name = "myObject",
+                Node = new Node(new XElement("node", new XAttribute("class", "myClass"), new XAttribute("resource-id", "myResourceId")), null),
+                Optimal = new OptimalWith
+                {
+                    Node = mainNode,
+                    Withs = new List<AttributeTags>
+                {
+                    AttributeTags.Class,
+                    AttributeTags.ResourceId
+                },
+                    Parent = new OptimalWith
+                    {
+                        Node = parentNode,
+                        Withs = new List<AttributeTags>
+                        {
+                            AttributeTags.Package
+                        },
+                        Parent = new OptimalWith
+                        {
+                            Node = superParentNode,
+                            Withs = new List<AttributeTags>
+                            {
+                                AttributeTags.Class
+                            }
+                        }
+                    }
+                }
+            };
+
+            var code = _codeService.GeneratePageObject("test", "test", new List<UiObjectInfo> { pageObjectInfo });
+            Assert.IsTrue(code.Contains("CreateUiObject(With.Class(\"myClass\"), With.ResourceId(\"myResourceId\"));"));
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Services/CodeServiceTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Services/CodeServiceTests.cs
@@ -62,11 +62,10 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
             var parentNode = new Node(new XElement("node", new XAttribute("class", "myClass"), new XAttribute("package", "package")), null);
             var mainNode = new Node(new XElement("node", new XAttribute("class", "myClass"), new XAttribute("resource-id", "myResourceId")), parentNode);
             
-
             var pageObjectInfo = new UiObjectInfo
             {
                 Name = "myObject",
-                Node = new Node(new XElement("node", new XAttribute("class", "myClass"), new XAttribute("resource-id", "myResourceId")), null),
+                Node = mainNode,
                 Optimal = new OptimalWith
                 {
                     Node = mainNode,
@@ -87,7 +86,7 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
             };
 
             var code = _codeService.GeneratePageObject("test", "test", new List<UiObjectInfo> { pageObjectInfo });
-            Assert.IsTrue(code.Contains("CreateUiObject(With.Class(\"myClass\"), With.ResourceId(\"myResourceId\"));"));
+            Assert.IsTrue(code.Contains("n => n.Parent?.Package == \"package\" && n.Class == \"myClass\" && n.ResourceId == \"myResourceId\""));
         }
 
         [Test]
@@ -130,7 +129,7 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
             };
 
             var code = _codeService.GeneratePageObject("test", "test", new List<UiObjectInfo> { pageObjectInfo });
-            Assert.IsTrue(code.Contains("CreateUiObject(With.Class(\"myClass\"), With.ResourceId(\"myResourceId\"));"));
+            Assert.IsTrue(code.Contains("n.Parent?.Parent?.Class == \"oldi\""));
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Services/CodeServiceTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Services/CodeServiceTests.cs
@@ -44,7 +44,7 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
             {
                 Name = "myObject",
                 Node = new Node(new XElement("node", new XAttribute("class", "myClass"), new XAttribute("resource-id", "myResourceId")), null),
-                Optimal = new OptimalWith { Withs = new List<AttributeTags>
+                AutoSelectedWith = new AutoSelectedWith { Withs = new List<AttributeTags>
                 {
                     AttributeTags.Class,
                     AttributeTags.ResourceId
@@ -66,7 +66,7 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
             {
                 Name = "myObject",
                 Node = mainNode,
-                Optimal = new OptimalWith
+                AutoSelectedWith = new AutoSelectedWith
                 {
                     Node = mainNode,
                     Withs = new List<AttributeTags>
@@ -74,7 +74,7 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
                     AttributeTags.Class,
                     AttributeTags.ResourceId
                 },
-                    Parent = new OptimalWith
+                    Parent = new AutoSelectedWith
                     {
                         Node = parentNode,
                         Withs = new List<AttributeTags>
@@ -101,7 +101,7 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
             {
                 Name = "myObject",
                 Node = new Node(new XElement("node", new XAttribute("class", "myClass"), new XAttribute("resource-id", "myResourceId")), null),
-                Optimal = new OptimalWith
+                AutoSelectedWith = new AutoSelectedWith
                 {
                     Node = mainNode,
                     Withs = new List<AttributeTags>
@@ -109,14 +109,14 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
                     AttributeTags.Class,
                     AttributeTags.ResourceId
                 },
-                    Parent = new OptimalWith
+                    Parent = new AutoSelectedWith
                     {
                         Node = parentNode,
                         Withs = new List<AttributeTags>
                         {
                             AttributeTags.Package
                         },
-                        Parent = new OptimalWith
+                        Parent = new AutoSelectedWith
                         {
                             Node = superParentNode,
                             Withs = new List<AttributeTags>

--- a/src/Testura.Android.PageObjectCreator.Tests/Services/DeviceServiceTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Services/DeviceServiceTests.cs
@@ -1,0 +1,21 @@
+using Testura.Android.PageObjectCreator.Services;
+using NUnit.Framework;
+using Testura.Android.PageObjectCreator.Util;
+using Moq;
+
+namespace Testura.Android.PageObjectCreator.Tests.Services
+{
+    [TestFixture]
+    public class DeviceServiceTests
+    {
+        private Mock<ITerminal> terminalMock;
+        private DeviceService deviceService;
+
+        [SetUp]
+        public void SetUp()
+        {
+            terminalMock = new Mock<ITerminal>();
+            deviceService = new DeviceService(terminalMock.Object);
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Services/DeviceServiceTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Services/DeviceServiceTests.cs
@@ -8,14 +8,14 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
     [TestFixture]
     public class DeviceServiceTests
     {
-        private Mock<ITerminal> terminalMock;
-        private DeviceService deviceService;
+        private Mock<ITerminal> _terminalMock;
+        private DeviceService _deviceService;
 
         [SetUp]
         public void SetUp()
         {
-            terminalMock = new Mock<ITerminal>();
-            deviceService = new DeviceService(terminalMock.Object);
+            _terminalMock = new Mock<ITerminal>();
+            _deviceService = new DeviceService(_terminalMock.Object);
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Services/DialogServiceTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Services/DialogServiceTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Services;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Services
+{
+    [TestFixture]
+    public class DialogServiceTests
+    {
+        private DialogService dialogService;
+
+        [SetUp]
+        public void SetUp()
+        {
+            dialogService = new DialogService();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Services/DialogServiceTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Services/DialogServiceTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
     [TestFixture]
     public class DialogServiceTests
     {
-        private DialogService dialogService;
+        private DialogService _dialogService;
 
         [SetUp]
         public void SetUp()
         {
-            dialogService = new DialogService();
+            _dialogService = new DialogService();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Services/DumpServiceTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Services/DumpServiceTests.cs
@@ -1,0 +1,21 @@
+using Testura.Android.PageObjectCreator.Services;
+using NUnit.Framework;
+using Testura.Android.PageObjectCreator.Util;
+using Moq;
+
+namespace Testura.Android.PageObjectCreator.Tests.Services
+{
+    [TestFixture]
+    public class DumpServiceTests
+    {
+        private Mock<ITerminal> terminalMock;
+        private DumpService dumpService;
+
+        [SetUp]
+        public void SetUp()
+        {
+            terminalMock = new Mock<ITerminal>();
+            dumpService = new DumpService(terminalMock.Object);
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Services/DumpServiceTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Services/DumpServiceTests.cs
@@ -8,14 +8,14 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
     [TestFixture]
     public class DumpServiceTests
     {
-        private Mock<ITerminal> terminalMock;
-        private DumpService dumpService;
+        private Mock<ITerminal> _terminalMock;
+        private DumpService _dumpService;
 
         [SetUp]
         public void SetUp()
         {
-            terminalMock = new Mock<ITerminal>();
-            dumpService = new DumpService(terminalMock.Object);
+            _terminalMock = new Mock<ITerminal>();
+            _dumpService = new DumpService(_terminalMock.Object);
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Services/FileServiceTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Services/FileServiceTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
     [TestFixture]
     public class FileServiceTests
     {
-        private FileService fileService;
+        private FileService _fileService;
 
         [SetUp]
         public void SetUp()
         {
-            fileService = new FileService();
+            _fileService = new FileService();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Services/FileServiceTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Services/FileServiceTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Services;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Services
+{
+    [TestFixture]
+    public class FileServiceTests
+    {
+        private FileService fileService;
+
+        [SetUp]
+        public void SetUp()
+        {
+            fileService = new FileService();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Services/OptimalWithServiceTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Services/OptimalWithServiceTests.cs
@@ -12,19 +12,19 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
     [TestFixture]
     public class OptimalWithServiceTests
     {
-        private IAutoSelectedWithFinderService _autoSelectedWithFinderService;
+        private IUniqueWithFinderService _uniqueWithFinderService;
 
         [SetUp]
         public void SetUp()
         {
-            _autoSelectedWithFinderService = new UniqueWithFinderService();
+            _uniqueWithFinderService = new UniqueWithFinderService();
         }
 
         [Test]
         public void GetOptimalWith_WhenOnlyHavingOneNodeAndResourceId_ShouldGetResourceId()
         {
             var node = new Node(new XElement("node", new XAttribute("resource-id", "test")), null);
-            var withs = _autoSelectedWithFinderService.GetUniqueWiths(node, new List<Node>() { node });
+            var withs = _uniqueWithFinderService.GetUniqueWiths(node, new List<Node>() { node });
             Assert.AreEqual(1, withs.Withs.Count);
             Assert.AreEqual(AttributeTags.ResourceId, withs.Withs.First());
         }
@@ -33,7 +33,7 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
         public void GetOptimalWith_WhenOnlyHavingOneNodeResourceIdIsEmpty_ShouldNotGetResourceId()
         {
             var node = new Node(new XElement("node", new XAttribute("resource-id", ""), new XAttribute("package", "test")), null);
-            var withs = _autoSelectedWithFinderService.GetUniqueWiths(node, new List<Node>() { node });
+            var withs = _uniqueWithFinderService.GetUniqueWiths(node, new List<Node>() { node });
             Assert.AreEqual(1, withs.Withs.Count);
             Assert.AreEqual(AttributeTags.Package, withs.Withs.First());
         }
@@ -43,7 +43,7 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
         {
             var node = new Node(new XElement("node", new XAttribute("resource-id", "test"), new XAttribute("package", "test")), null);
             var secondNode = new Node(new XElement("node", new XAttribute("resource-id", "test")), null);
-            var withs = _autoSelectedWithFinderService.GetUniqueWiths(node, new List<Node>() { node, secondNode });
+            var withs = _uniqueWithFinderService.GetUniqueWiths(node, new List<Node>() { node, secondNode });
             Assert.AreEqual(1, withs.Withs.Count);
             Assert.AreEqual(AttributeTags.Package, withs.Withs.First());
         }
@@ -54,7 +54,7 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
             var node = new Node(new XElement("node", new XAttribute("resource-id", "test"), new XAttribute("package", "test")), null);
             var secondNode = new Node(new XElement("node", new XAttribute("resource-id", "test")), null);
             var thirdNode = new Node(new XElement("node", new XAttribute("package", "test")), null);
-            var withs = _autoSelectedWithFinderService.GetUniqueWiths(node, new List<Node>() { node, secondNode, thirdNode });
+            var withs = _uniqueWithFinderService.GetUniqueWiths(node, new List<Node>() { node, secondNode, thirdNode });
             Assert.AreEqual(2, withs.Withs.Count);
             Assert.AreEqual(AttributeTags.ResourceId, withs.Withs.First());
             Assert.AreEqual(AttributeTags.Package, withs.Withs.Last());
@@ -68,7 +68,7 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
             parent.Children.Add(node);
             var secondNode = new Node(new XElement("node", new XAttribute("package", "test"), new XAttribute("resource-id", "test")), null);
             var thirdNode = new Node(new XElement("node", new XAttribute("resource-id", "test"), new XAttribute("package", "test")), null);
-            var withs = _autoSelectedWithFinderService.GetUniqueWiths(node, new List<Node>() { node, secondNode, thirdNode, parent });
+            var withs = _uniqueWithFinderService.GetUniqueWiths(node, new List<Node>() { node, secondNode, thirdNode, parent });
             Assert.AreEqual(1, withs.Withs.Count);
             Assert.IsNotNull(withs.Parent);
             Assert.AreEqual(AttributeTags.ResourceId, withs.Withs.First());
@@ -84,7 +84,7 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
             parent.Children.Add(otherChildNode);
             var secondNode = new Node(new XElement("node", new XAttribute("package", "test"), new XAttribute("resource-id", "test")), null);
             var thirdNode = new Node(new XElement("node", new XAttribute("resource-id", "test"), new XAttribute("package", "test")), null);
-            var withs = _autoSelectedWithFinderService.GetUniqueWiths(node, new List<Node>() { node, secondNode, thirdNode, parent, otherChildNode});
+            var withs = _uniqueWithFinderService.GetUniqueWiths(node, new List<Node>() { node, secondNode, thirdNode, parent, otherChildNode});
             Assert.AreEqual(1, withs.Withs.Count);
             Assert.IsNotNull(withs.Parent);
             Assert.AreEqual(AttributeTags.Package, withs.Withs.First());

--- a/src/Testura.Android.PageObjectCreator.Tests/Services/OptimalWithServiceTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Services/OptimalWithServiceTests.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Xml.Linq;
+using NUnit.Framework;
+using Testura.Android.Device.Ui.Nodes.Data;
+using Testura.Android.PageObjectCreator.Services;
+using Testura.Android.Util;
+
+namespace Testura.Android.PageObjectCreator.Tests.Services
+{
+    [TestFixture]
+    public class OptimalWithServiceTests
+    {
+        private IOptimalWithService _optimalWithService;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _optimalWithService = new OptimalWithService();
+        }
+
+        [Test]
+        public void GetOptimalWith_WhenOnlyHavingOneNodeAndResourceId_ShouldGetResourceId()
+        {
+            var node = new Node(new XElement("node", new XAttribute("resource-id", "test")), null);
+            var withs = _optimalWithService.GetOptimalWith(node, new List<Node>() { node });
+            Assert.AreEqual(1, withs.Withs.Count);
+            Assert.AreEqual(AttributeTags.ResourceId, withs.Withs.First());
+        }
+
+        [Test]
+        public void GetOptimalWith_WhenOnlyHavingTwoWithSameResoruceId_ShouldGetPackage()
+        {
+            var node = new Node(new XElement("node", new XAttribute("resource-id", "test"), new XAttribute("package", "test")), null);
+            var secondNode = new Node(new XElement("node", new XAttribute("resource-id", "test")), null);
+            var withs = _optimalWithService.GetOptimalWith(node, new List<Node>() { node, secondNode });
+            Assert.AreEqual(1, withs.Withs.Count);
+            Assert.AreEqual(AttributeTags.Package, withs.Withs.First());
+        }
+
+        [Test]
+        public void GetOptimalWith_WhenOnlyHavingSameResourceIdAndPackageAsTwoOther_ShouldGetCombinationResourceIdAndPackage()
+        {
+            var node = new Node(new XElement("node", new XAttribute("resource-id", "test"), new XAttribute("package", "test")), null);
+            var secondNode = new Node(new XElement("node", new XAttribute("resource-id", "test")), null);
+            var thirdNode = new Node(new XElement("node", new XAttribute("package", "test")), null);
+            var withs = _optimalWithService.GetOptimalWith(node, new List<Node>() { node, secondNode, thirdNode });
+            Assert.AreEqual(2, withs.Withs.Count);
+            Assert.AreEqual(AttributeTags.ResourceId, withs.Withs.First());
+            Assert.AreEqual(AttributeTags.Package, withs.Withs.Last());
+        }
+
+        [Test]
+        public void GetOptimalWith_WhenNoUniqueValuesAndHaveToUseParent_ShouldGetParent()
+        {
+            var parent = new Node(new XElement("node", new XAttribute("resource-id", "hej"), new XAttribute("package", "bleh")), null);
+            var node = new Node(new XElement("node", new XAttribute("resource-id", "test"), new XAttribute("package", "test")), parent);
+            parent.Children.Add(node);
+            var secondNode = new Node(new XElement("node", new XAttribute("package", "test"), new XAttribute("resource-id", "test")), null);
+            var thirdNode = new Node(new XElement("node", new XAttribute("resource-id", "test"), new XAttribute("package", "test")), null);
+            var withs = _optimalWithService.GetOptimalWith(node, new List<Node>() { node, secondNode, thirdNode, parent });
+            Assert.AreEqual(1, withs.Withs.Count);
+            Assert.IsNotNull(withs.Parent);
+            Assert.AreEqual(AttributeTags.ResourceId, withs.Withs.First());
+        }
+
+        [Test]
+        public void GetOptimalWith_WhenNoUniqueValuesAndHaveToUseParentAndParentsOtherChildrenHaveSameResourceId_ShouldGetParentAndUsePackage()
+        {
+            var parent = new Node(new XElement("node", new XAttribute("resource-id", "hej"), new XAttribute("package", "bleh")), null);
+            var node = new Node(new XElement("node", new XAttribute("resource-id", "test"), new XAttribute("package", "test")), parent);
+            var otherChildNode = new Node(new XElement("node", new XAttribute("resource-id", "test")), parent);
+            parent.Children.Add(node);
+            parent.Children.Add(otherChildNode);
+            var secondNode = new Node(new XElement("node", new XAttribute("package", "test"), new XAttribute("resource-id", "test")), null);
+            var thirdNode = new Node(new XElement("node", new XAttribute("resource-id", "test"), new XAttribute("package", "test")), null);
+            var withs = _optimalWithService.GetOptimalWith(node, new List<Node>() { node, secondNode, thirdNode, parent, otherChildNode});
+            Assert.AreEqual(1, withs.Withs.Count);
+            Assert.IsNotNull(withs.Parent);
+            Assert.AreEqual(AttributeTags.Package, withs.Withs.First());
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Services/OptimalWithServiceTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Services/OptimalWithServiceTests.cs
@@ -30,6 +30,15 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
         }
 
         [Test]
+        public void GetOptimalWith_WhenOnlyHavingOneNodeResourceIdIsEmpty_ShouldNotGetResourceId()
+        {
+            var node = new Node(new XElement("node", new XAttribute("resource-id", ""), new XAttribute("package", "test")), null);
+            var withs = _optimalWithService.GetOptimalWith(node, new List<Node>() { node });
+            Assert.AreEqual(1, withs.Withs.Count);
+            Assert.AreEqual(AttributeTags.Package, withs.Withs.First());
+        }
+
+        [Test]
         public void GetOptimalWith_WhenOnlyHavingTwoWithSameResoruceId_ShouldGetPackage()
         {
             var node = new Node(new XElement("node", new XAttribute("resource-id", "test"), new XAttribute("package", "test")), null);

--- a/src/Testura.Android.PageObjectCreator.Tests/Services/OptimalWithServiceTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Services/OptimalWithServiceTests.cs
@@ -12,19 +12,19 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
     [TestFixture]
     public class OptimalWithServiceTests
     {
-        private IOptimalWithService _optimalWithService;
+        private IAutoSelectedWithFinderService _autoSelectedWithFinderService;
 
         [SetUp]
         public void SetUp()
         {
-            _optimalWithService = new OptimalWithService();
+            _autoSelectedWithFinderService = new UniqueWithFinderService();
         }
 
         [Test]
         public void GetOptimalWith_WhenOnlyHavingOneNodeAndResourceId_ShouldGetResourceId()
         {
             var node = new Node(new XElement("node", new XAttribute("resource-id", "test")), null);
-            var withs = _optimalWithService.GetOptimalWith(node, new List<Node>() { node });
+            var withs = _autoSelectedWithFinderService.GetUniqueWiths(node, new List<Node>() { node });
             Assert.AreEqual(1, withs.Withs.Count);
             Assert.AreEqual(AttributeTags.ResourceId, withs.Withs.First());
         }
@@ -33,7 +33,7 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
         public void GetOptimalWith_WhenOnlyHavingOneNodeResourceIdIsEmpty_ShouldNotGetResourceId()
         {
             var node = new Node(new XElement("node", new XAttribute("resource-id", ""), new XAttribute("package", "test")), null);
-            var withs = _optimalWithService.GetOptimalWith(node, new List<Node>() { node });
+            var withs = _autoSelectedWithFinderService.GetUniqueWiths(node, new List<Node>() { node });
             Assert.AreEqual(1, withs.Withs.Count);
             Assert.AreEqual(AttributeTags.Package, withs.Withs.First());
         }
@@ -43,7 +43,7 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
         {
             var node = new Node(new XElement("node", new XAttribute("resource-id", "test"), new XAttribute("package", "test")), null);
             var secondNode = new Node(new XElement("node", new XAttribute("resource-id", "test")), null);
-            var withs = _optimalWithService.GetOptimalWith(node, new List<Node>() { node, secondNode });
+            var withs = _autoSelectedWithFinderService.GetUniqueWiths(node, new List<Node>() { node, secondNode });
             Assert.AreEqual(1, withs.Withs.Count);
             Assert.AreEqual(AttributeTags.Package, withs.Withs.First());
         }
@@ -54,7 +54,7 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
             var node = new Node(new XElement("node", new XAttribute("resource-id", "test"), new XAttribute("package", "test")), null);
             var secondNode = new Node(new XElement("node", new XAttribute("resource-id", "test")), null);
             var thirdNode = new Node(new XElement("node", new XAttribute("package", "test")), null);
-            var withs = _optimalWithService.GetOptimalWith(node, new List<Node>() { node, secondNode, thirdNode });
+            var withs = _autoSelectedWithFinderService.GetUniqueWiths(node, new List<Node>() { node, secondNode, thirdNode });
             Assert.AreEqual(2, withs.Withs.Count);
             Assert.AreEqual(AttributeTags.ResourceId, withs.Withs.First());
             Assert.AreEqual(AttributeTags.Package, withs.Withs.Last());
@@ -68,7 +68,7 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
             parent.Children.Add(node);
             var secondNode = new Node(new XElement("node", new XAttribute("package", "test"), new XAttribute("resource-id", "test")), null);
             var thirdNode = new Node(new XElement("node", new XAttribute("resource-id", "test"), new XAttribute("package", "test")), null);
-            var withs = _optimalWithService.GetOptimalWith(node, new List<Node>() { node, secondNode, thirdNode, parent });
+            var withs = _autoSelectedWithFinderService.GetUniqueWiths(node, new List<Node>() { node, secondNode, thirdNode, parent });
             Assert.AreEqual(1, withs.Withs.Count);
             Assert.IsNotNull(withs.Parent);
             Assert.AreEqual(AttributeTags.ResourceId, withs.Withs.First());
@@ -84,7 +84,7 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
             parent.Children.Add(otherChildNode);
             var secondNode = new Node(new XElement("node", new XAttribute("package", "test"), new XAttribute("resource-id", "test")), null);
             var thirdNode = new Node(new XElement("node", new XAttribute("resource-id", "test"), new XAttribute("package", "test")), null);
-            var withs = _optimalWithService.GetOptimalWith(node, new List<Node>() { node, secondNode, thirdNode, parent, otherChildNode});
+            var withs = _autoSelectedWithFinderService.GetUniqueWiths(node, new List<Node>() { node, secondNode, thirdNode, parent, otherChildNode});
             Assert.AreEqual(1, withs.Withs.Count);
             Assert.IsNotNull(withs.Parent);
             Assert.AreEqual(AttributeTags.Package, withs.Withs.First());

--- a/src/Testura.Android.PageObjectCreator.Tests/Services/ScreenServiceTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Services/ScreenServiceTests.cs
@@ -7,14 +7,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Services
     [TestFixture]
     public class ScreenServiceTests
     {
-        private Mock<IDumpService> dumpServiceMock;
-        private ScreenService screenService;
+        private ScreenService _screenService;
 
         [SetUp]
         public void SetUp()
         {
-            dumpServiceMock = new Mock<IDumpService>();
-            screenService = new ScreenService(dumpServiceMock.Object);
+            _screenService = new ScreenService();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Services/ScreenServiceTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Services/ScreenServiceTests.cs
@@ -1,0 +1,20 @@
+using Testura.Android.PageObjectCreator.Services;
+using NUnit.Framework;
+using Moq;
+
+namespace Testura.Android.PageObjectCreator.Tests.Services
+{
+    [TestFixture]
+    public class ScreenServiceTests
+    {
+        private Mock<IDumpService> dumpServiceMock;
+        private ScreenService screenService;
+
+        [SetUp]
+        public void SetUp()
+        {
+            dumpServiceMock = new Mock<IDumpService>();
+            screenService = new ScreenService(dumpServiceMock.Object);
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Testura.Android.PageObjectCreator.Tests.csproj
+++ b/src/Testura.Android.PageObjectCreator.Tests/Testura.Android.PageObjectCreator.Tests.csproj
@@ -1,0 +1,130 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\MSTest.TestAdapter.1.1.8-rc2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.1.8-rc2\build\net45\MSTest.TestAdapter.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9D8231F0-73FE-4610-B4AB-A642D9AAA5AD}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Testura.Android.PageObjectCreator.Tests</RootNamespace>
+    <AssemblyName>Testura.Android.PageObjectCreator.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MSTest.TestFramework.1.0.8-rc2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MSTest.TestFramework.1.0.8-rc2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq, Version=4.7.1.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.7.1\lib\net45\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Dialogs\AboutDialogTests.cs" />
+    <Compile Include="Dialogs\ErrorDialogTests.cs" />
+    <Compile Include="Dialogs\NameDialogTests.cs" />
+    <Compile Include="Dialogs\WithDialogTests.cs" />
+    <Compile Include="Models\AndroidDumpInfoTests.cs" />
+    <Compile Include="Models\AttributeTests.cs" />
+    <Compile Include="Models\ImageScaleTests.cs" />
+    <Compile Include="Models\Messages\AddNodeMessageTests.cs" />
+    <Compile Include="Models\Messages\AddUiObjectInfoMessageTests.cs" />
+    <Compile Include="Models\Messages\DeviceAvailableMessageTests.cs" />
+    <Compile Include="Models\Messages\DumpMessageTests.cs" />
+    <Compile Include="Models\Messages\PageObjectChangedMessageTests.cs" />
+    <Compile Include="Models\Messages\RequestDumpMessageTests.cs" />
+    <Compile Include="Models\Messages\RequestRefreshDeviceListCommandTests.cs" />
+    <Compile Include="Models\Messages\SelectedDeviceChangedMessageTests.cs" />
+    <Compile Include="Models\Messages\SelectedHierarchyNodeMesssageTests.cs" />
+    <Compile Include="Models\Messages\ShowNodeDetailsMessageTests.cs" />
+    <Compile Include="Models\Messages\StartedDumpScreenMessageTests.cs" />
+    <Compile Include="Models\Messages\StoppedDumpScreenMessageTests.cs" />
+    <Compile Include="Models\Messages\UiObjectInfoRemovedMessageTests.cs" />
+    <Compile Include="Models\PageObjectTests.cs" />
+    <Compile Include="Models\UiObjectInfoTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Services\DeviceServiceTests.cs" />
+    <Compile Include="Services\DialogServiceTests.cs" />
+    <Compile Include="Services\DumpServiceTests.cs" />
+    <Compile Include="Services\FileServiceTests.cs" />
+    <Compile Include="Services\ScreenServiceTests.cs" />
+    <Compile Include="Testura\Android\PageObjectCreator\AppTests.cs" />
+    <Compile Include="Testura\Android\PageObjectCreator\MainWindowTests.cs" />
+    <Compile Include="Util\Behaviors\AvalonEditBehaviorTests.cs" />
+    <Compile Include="Util\Converters\BooleanToVisibilityInvertedConverterTests.cs" />
+    <Compile Include="Util\Converters\InvertBooleanConverterTests.cs" />
+    <Compile Include="Util\Converters\NodeToHierarchyTextConverterTests.cs" />
+    <Compile Include="Util\TerminalTests.cs" />
+    <Compile Include="ViewModels\CodeViewModelTests.cs" />
+    <Compile Include="ViewModels\DeviceViewModelTests.cs" />
+    <Compile Include="ViewModels\HierarchyViewModelTests.cs" />
+    <Compile Include="ViewModels\MainViewModelTests.cs" />
+    <Compile Include="ViewModels\OperationViewModelTests.cs" />
+    <Compile Include="ViewModels\PageObjectViewModelTests.cs" />
+    <Compile Include="ViewModels\ScreenViewModelTests.cs" />
+    <Compile Include="ViewModels\ViewModelLocatorTests.cs" />
+    <Compile Include="ViewModels\WithViewModelTests.cs" />
+    <Compile Include="Views\CodeViewTests.cs" />
+    <Compile Include="Views\DeviceViewTests.cs" />
+    <Compile Include="Views\HierarchyViewTests.cs" />
+    <Compile Include="Views\OperationViewTests.cs" />
+    <Compile Include="Views\PageObjectViewTests.cs" />
+    <Compile Include="Views\ScreenViewTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Testura.Android.PageObjectCreator\Testura.Android.PageObjectCreator.csproj">
+      <Project>{1b800835-5be3-485e-a622-4d8225c8dd9e}</Project>
+      <Name>Testura.Android.PageObjectCreator</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.1.8-rc2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.1.8-rc2\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.1.8-rc2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.1.8-rc2\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\..\packages\MSTest.TestAdapter.1.1.8-rc2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.1.8-rc2\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/src/Testura.Android.PageObjectCreator.Tests/Testura.Android.PageObjectCreator.Tests.csproj
+++ b/src/Testura.Android.PageObjectCreator.Tests/Testura.Android.PageObjectCreator.Tests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Models\PageObjectTests.cs" />
     <Compile Include="Models\UiObjectInfoTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Services\CodeServiceTests.cs" />
     <Compile Include="Services\DeviceServiceTests.cs" />
     <Compile Include="Services\DialogServiceTests.cs" />
     <Compile Include="Services\DumpServiceTests.cs" />

--- a/src/Testura.Android.PageObjectCreator.Tests/Testura.Android.PageObjectCreator.Tests.csproj
+++ b/src/Testura.Android.PageObjectCreator.Tests/Testura.Android.PageObjectCreator.Tests.csproj
@@ -41,6 +41,9 @@
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
+    <Reference Include="MedallionShell, Version=1.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MedallionShell.1.2.1\lib\net45\MedallionShell.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MSTest.TestFramework.1.0.8-rc2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
@@ -55,6 +58,10 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="Testura.Android, Version=0.9.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Testura.Android.0.9.2\lib\net452\Testura.Android.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Dialogs\AboutDialogTests.cs" />
@@ -84,6 +91,7 @@
     <Compile Include="Services\DialogServiceTests.cs" />
     <Compile Include="Services\DumpServiceTests.cs" />
     <Compile Include="Services\FileServiceTests.cs" />
+    <Compile Include="Services\OptimalWithServiceTests.cs" />
     <Compile Include="Services\ScreenServiceTests.cs" />
     <Compile Include="Testura\Android\PageObjectCreator\AppTests.cs" />
     <Compile Include="Testura\Android\PageObjectCreator\MainWindowTests.cs" />
@@ -109,7 +117,9 @@
     <Compile Include="Views\ScreenViewTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Testura.Android.PageObjectCreator\Testura.Android.PageObjectCreator.csproj">
@@ -125,6 +135,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.1.8-rc2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.1.8-rc2\build\net45\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.1.8-rc2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.1.8-rc2\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Testura.Android.0.9.2\build\testura.android.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Testura.Android.0.9.2\build\testura.android.targets'))" />
   </Target>
   <Import Project="..\..\packages\MSTest.TestAdapter.1.1.8-rc2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.1.8-rc2\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\..\packages\Testura.Android.0.9.2\build\testura.android.targets" Condition="Exists('..\..\packages\Testura.Android.0.9.2\build\testura.android.targets')" />
 </Project>

--- a/src/Testura.Android.PageObjectCreator.Tests/Testura/Android/PageObjectCreator/AppTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Testura/Android/PageObjectCreator/AppTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests
     [TestFixture]
     public class AppTests
     {
-        private App app;
+        private App _app;
 
         [SetUp]
         public void SetUp()
         {
-            app = new App();
+            _app = new App();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Testura/Android/PageObjectCreator/AppTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Testura/Android/PageObjectCreator/AppTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests
+{
+    [TestFixture]
+    public class AppTests
+    {
+        private App app;
+
+        [SetUp]
+        public void SetUp()
+        {
+            app = new App();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Testura/Android/PageObjectCreator/MainWindowTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Testura/Android/PageObjectCreator/MainWindowTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests
+{
+    [TestFixture]
+    public class MainWindowTests
+    {
+        private MainWindow mainWindow;
+
+        [SetUp]
+        public void SetUp()
+        {
+            mainWindow = new MainWindow();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Testura/Android/PageObjectCreator/MainWindowTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Testura/Android/PageObjectCreator/MainWindowTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests
     [TestFixture]
     public class MainWindowTests
     {
-        private MainWindow mainWindow;
+        private MainWindow _mainWindow;
 
         [SetUp]
         public void SetUp()
         {
-            mainWindow = new MainWindow();
+            _mainWindow = new MainWindow();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Util/Behaviors/AvalonEditBehaviorTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Util/Behaviors/AvalonEditBehaviorTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Util.Behaviors;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Util.Behaviors
+{
+    [TestFixture]
+    public class AvalonEditBehaviorTests
+    {
+        private AvalonEditBehavior avalonEditBehavior;
+
+        [SetUp]
+        public void SetUp()
+        {
+            avalonEditBehavior = new AvalonEditBehavior();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Util/Behaviors/AvalonEditBehaviorTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Util/Behaviors/AvalonEditBehaviorTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Util.Behaviors
     [TestFixture]
     public class AvalonEditBehaviorTests
     {
-        private AvalonEditBehavior avalonEditBehavior;
+        private AvalonEditBehavior _avalonEditBehavior;
 
         [SetUp]
         public void SetUp()
         {
-            avalonEditBehavior = new AvalonEditBehavior();
+            _avalonEditBehavior = new AvalonEditBehavior();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Util/Converters/BooleanToVisibilityInvertedConverterTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Util/Converters/BooleanToVisibilityInvertedConverterTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Util.Converters;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Util.Converters
+{
+    [TestFixture]
+    public class BooleanToVisibilityInvertedConverterTests
+    {
+        private BooleanToVisibilityInvertedConverter booleanToVisibilityInvertedConverter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            booleanToVisibilityInvertedConverter = new BooleanToVisibilityInvertedConverter();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Util/Converters/BooleanToVisibilityInvertedConverterTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Util/Converters/BooleanToVisibilityInvertedConverterTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Util.Converters
     [TestFixture]
     public class BooleanToVisibilityInvertedConverterTests
     {
-        private BooleanToVisibilityInvertedConverter booleanToVisibilityInvertedConverter;
+        private BooleanToVisibilityInvertedConverter _booleanToVisibilityInvertedConverter;
 
         [SetUp]
         public void SetUp()
         {
-            booleanToVisibilityInvertedConverter = new BooleanToVisibilityInvertedConverter();
+            _booleanToVisibilityInvertedConverter = new BooleanToVisibilityInvertedConverter();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Util/Converters/InvertBooleanConverterTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Util/Converters/InvertBooleanConverterTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Util.Converters;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Util.Converters
+{
+    [TestFixture]
+    public class InvertBooleanConverterTests
+    {
+        private InvertBooleanConverter invertBooleanConverter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            invertBooleanConverter = new InvertBooleanConverter();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Util/Converters/InvertBooleanConverterTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Util/Converters/InvertBooleanConverterTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Util.Converters
     [TestFixture]
     public class InvertBooleanConverterTests
     {
-        private InvertBooleanConverter invertBooleanConverter;
+        private InvertBooleanConverter _invertBooleanConverter;
 
         [SetUp]
         public void SetUp()
         {
-            invertBooleanConverter = new InvertBooleanConverter();
+            _invertBooleanConverter = new InvertBooleanConverter();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Util/Converters/NodeToHierarchyTextConverterTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Util/Converters/NodeToHierarchyTextConverterTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Util.Converters
     [TestFixture]
     public class NodeToHierarchyTextConverterTests
     {
-        private NodeToHierarchyTextConverter nodeToHierarchyTextConverter;
+        private NodeToHierarchyTextConverter _nodeToHierarchyTextConverter;
 
         [SetUp]
         public void SetUp()
         {
-            nodeToHierarchyTextConverter = new NodeToHierarchyTextConverter();
+            _nodeToHierarchyTextConverter = new NodeToHierarchyTextConverter();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Util/Converters/NodeToHierarchyTextConverterTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Util/Converters/NodeToHierarchyTextConverterTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Util.Converters;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Util.Converters
+{
+    [TestFixture]
+    public class NodeToHierarchyTextConverterTests
+    {
+        private NodeToHierarchyTextConverter nodeToHierarchyTextConverter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            nodeToHierarchyTextConverter = new NodeToHierarchyTextConverter();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Util/TerminalTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Util/TerminalTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Util;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Util
+{
+    [TestFixture]
+    public class TerminalTests
+    {
+        private Terminal terminal;
+
+        [SetUp]
+        public void SetUp()
+        {
+            terminal = new Terminal();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Util/TerminalTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Util/TerminalTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Util
     [TestFixture]
     public class TerminalTests
     {
-        private Terminal terminal;
+        private Terminal _terminal;
 
         [SetUp]
         public void SetUp()
         {
-            terminal = new Terminal();
+            _terminal = new Terminal();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/CodeViewModelTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/CodeViewModelTests.cs
@@ -1,17 +1,21 @@
+using Moq;
 using Testura.Android.PageObjectCreator.ViewModels;
 using NUnit.Framework;
+using Testura.Android.PageObjectCreator.Services;
 
 namespace Testura.Android.PageObjectCreator.Tests.ViewModels
 {
     [TestFixture]
     public class CodeViewModelTests
     {
-        private CodeViewModel codeViewModel;
+        private Mock<ICodeService> _codeServiceMock;
+        private CodeViewModel _codeViewModel;
 
         [SetUp]
         public void SetUp()
         {
-            codeViewModel = new CodeViewModel();
+            _codeServiceMock = new Mock<ICodeService>();
+            _codeViewModel = new CodeViewModel(_codeServiceMock.Object);
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/CodeViewModelTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/CodeViewModelTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.ViewModels;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.ViewModels
+{
+    [TestFixture]
+    public class CodeViewModelTests
+    {
+        private CodeViewModel codeViewModel;
+
+        [SetUp]
+        public void SetUp()
+        {
+            codeViewModel = new CodeViewModel();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/DeviceViewModelTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/DeviceViewModelTests.cs
@@ -8,14 +8,14 @@ namespace Testura.Android.PageObjectCreator.Tests.ViewModels
     [TestFixture]
     public class DeviceViewModelTests
     {
-        private Mock<IDeviceService> deviceServiceMock;
-        private DeviceViewModel deviceViewModel;
+        private Mock<IDeviceService> _deviceServiceMock;
+        private DeviceViewModel _deviceViewModel;
 
         [SetUp]
         public void SetUp()
         {
-            deviceServiceMock = new Mock<IDeviceService>();
-            deviceViewModel = new DeviceViewModel(deviceServiceMock.Object);
+            _deviceServiceMock = new Mock<IDeviceService>();
+            _deviceViewModel = new DeviceViewModel(_deviceServiceMock.Object);
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/DeviceViewModelTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/DeviceViewModelTests.cs
@@ -1,0 +1,21 @@
+using Testura.Android.PageObjectCreator.ViewModels;
+using NUnit.Framework;
+using Testura.Android.PageObjectCreator.Services;
+using Moq;
+
+namespace Testura.Android.PageObjectCreator.Tests.ViewModels
+{
+    [TestFixture]
+    public class DeviceViewModelTests
+    {
+        private Mock<IDeviceService> deviceServiceMock;
+        private DeviceViewModel deviceViewModel;
+
+        [SetUp]
+        public void SetUp()
+        {
+            deviceServiceMock = new Mock<IDeviceService>();
+            deviceViewModel = new DeviceViewModel(deviceServiceMock.Object);
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/HierarchyViewModelTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/HierarchyViewModelTests.cs
@@ -1,0 +1,23 @@
+using Testura.Android.PageObjectCreator.ViewModels;
+using NUnit.Framework;
+using Testura.Android.PageObjectCreator.Services;
+using Moq;
+
+namespace Testura.Android.PageObjectCreator.Tests.ViewModels
+{
+    [TestFixture]
+    public class HierarchyViewModelTests
+    {
+        private Mock<IDumpService> dumpServiceMock;
+        private Mock<IFileService> fileServiceMock;
+        private HierarchyViewModel hierarchyViewModel;
+
+        [SetUp]
+        public void SetUp()
+        {
+            dumpServiceMock = new Mock<IDumpService>();
+            fileServiceMock = new Mock<IFileService>();
+            hierarchyViewModel = new HierarchyViewModel(dumpServiceMock.Object, fileServiceMock.Object);
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/HierarchyViewModelTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/HierarchyViewModelTests.cs
@@ -8,12 +8,12 @@ namespace Testura.Android.PageObjectCreator.Tests.ViewModels
     [TestFixture]
     public class HierarchyViewModelTests
     {
-        private HierarchyViewModel hierarchyViewModel;
+        private HierarchyViewModel _hierarchyViewModel;
 
         [SetUp]
         public void SetUp()
         {
-            hierarchyViewModel = new HierarchyViewModel();
+            _hierarchyViewModel = new HierarchyViewModel();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/HierarchyViewModelTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/HierarchyViewModelTests.cs
@@ -8,16 +8,12 @@ namespace Testura.Android.PageObjectCreator.Tests.ViewModels
     [TestFixture]
     public class HierarchyViewModelTests
     {
-        private Mock<IDumpService> dumpServiceMock;
-        private Mock<IFileService> fileServiceMock;
         private HierarchyViewModel hierarchyViewModel;
 
         [SetUp]
         public void SetUp()
         {
-            dumpServiceMock = new Mock<IDumpService>();
-            fileServiceMock = new Mock<IFileService>();
-            hierarchyViewModel = new HierarchyViewModel(dumpServiceMock.Object, fileServiceMock.Object);
+            hierarchyViewModel = new HierarchyViewModel();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/MainViewModelTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/MainViewModelTests.cs
@@ -1,0 +1,21 @@
+using Testura.Android.PageObjectCreator.ViewModels;
+using NUnit.Framework;
+using Testura.Android.PageObjectCreator.Services;
+using Moq;
+
+namespace Testura.Android.PageObjectCreator.Tests.ViewModels
+{
+    [TestFixture]
+    public class MainViewModelTests
+    {
+        private Mock<IDialogService> dialogServiceMock;
+        private MainViewModel mainViewModel;
+
+        [SetUp]
+        public void SetUp()
+        {
+            dialogServiceMock = new Mock<IDialogService>();
+            mainViewModel = new MainViewModel(dialogServiceMock.Object);
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/MainViewModelTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/MainViewModelTests.cs
@@ -8,14 +8,14 @@ namespace Testura.Android.PageObjectCreator.Tests.ViewModels
     [TestFixture]
     public class MainViewModelTests
     {
-        private Mock<IDialogService> dialogServiceMock;
-        private MainViewModel mainViewModel;
+        private Mock<IDialogService> _dialogServiceMock;
+        private MainViewModel _mainViewModel;
 
         [SetUp]
         public void SetUp()
         {
-            dialogServiceMock = new Mock<IDialogService>();
-            mainViewModel = new MainViewModel(dialogServiceMock.Object);
+            _dialogServiceMock = new Mock<IDialogService>();
+            _mainViewModel = new MainViewModel(_dialogServiceMock.Object);
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/OperationViewModelTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/OperationViewModelTests.cs
@@ -1,0 +1,23 @@
+using Testura.Android.PageObjectCreator.ViewModels;
+using NUnit.Framework;
+using Testura.Android.PageObjectCreator.Services;
+using Moq;
+
+namespace Testura.Android.PageObjectCreator.Tests.ViewModels
+{
+    [TestFixture]
+    public class OperationViewModelTests
+    {
+        private Mock<IDumpService> dumpServiceMock;
+        private Mock<IDialogService> dialogServiceMock;
+        private OperationViewModel operationViewModel;
+
+        [SetUp]
+        public void SetUp()
+        {
+            dumpServiceMock = new Mock<IDumpService>();
+            dialogServiceMock = new Mock<IDialogService>();
+            operationViewModel = new OperationViewModel(dumpServiceMock.Object, dialogServiceMock.Object);
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/OperationViewModelTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/OperationViewModelTests.cs
@@ -8,18 +8,18 @@ namespace Testura.Android.PageObjectCreator.Tests.ViewModels
     [TestFixture]
     public class OperationViewModelTests
     {
-        private Mock<IDumpService> dumpServiceMock;
-        private Mock<IFileService> fileServiceMock;
-        private Mock<IDialogService> dialogServiceMock;
-        private OperationViewModel operationViewModel;
+        private Mock<IDumpService> _dumpServiceMock;
+        private Mock<IFileService> _fileServiceMock;
+        private Mock<IDialogService> _dialogServiceMock;
+        private OperationViewModel _operationViewModel;
 
         [SetUp]
         public void SetUp()
         {
-            dumpServiceMock = new Mock<IDumpService>();
-            dialogServiceMock = new Mock<IDialogService>();
-            fileServiceMock = new Mock<IFileService>();
-            operationViewModel = new OperationViewModel(dumpServiceMock.Object, fileServiceMock.Object, dialogServiceMock.Object);
+            _dumpServiceMock = new Mock<IDumpService>();
+            _dialogServiceMock = new Mock<IDialogService>();
+            _fileServiceMock = new Mock<IFileService>();
+            _operationViewModel = new OperationViewModel(_dumpServiceMock.Object, _fileServiceMock.Object, _dialogServiceMock.Object);
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/OperationViewModelTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/OperationViewModelTests.cs
@@ -9,6 +9,7 @@ namespace Testura.Android.PageObjectCreator.Tests.ViewModels
     public class OperationViewModelTests
     {
         private Mock<IDumpService> dumpServiceMock;
+        private Mock<IFileService> fileServiceMock;
         private Mock<IDialogService> dialogServiceMock;
         private OperationViewModel operationViewModel;
 
@@ -17,7 +18,8 @@ namespace Testura.Android.PageObjectCreator.Tests.ViewModels
         {
             dumpServiceMock = new Mock<IDumpService>();
             dialogServiceMock = new Mock<IDialogService>();
-            operationViewModel = new OperationViewModel(dumpServiceMock.Object, dialogServiceMock.Object);
+            fileServiceMock = new Mock<IFileService>();
+            operationViewModel = new OperationViewModel(dumpServiceMock.Object, fileServiceMock.Object, dialogServiceMock.Object);
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/PageObjectViewModelTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/PageObjectViewModelTests.cs
@@ -8,14 +8,14 @@ namespace Testura.Android.PageObjectCreator.Tests.ViewModels
     [TestFixture]
     public class PageObjectViewModelTests
     {
-        private Mock<IDialogService> dialogServiceMock;
-        private PageObjectViewModel pageObjectViewModel;
+        private Mock<IDialogService> _dialogServiceMock;
+        private PageObjectViewModel _pageObjectViewModel;
 
         [SetUp]
         public void SetUp()
         {
-            dialogServiceMock = new Mock<IDialogService>();
-            pageObjectViewModel = new PageObjectViewModel(dialogServiceMock.Object);
+            _dialogServiceMock = new Mock<IDialogService>();
+            _pageObjectViewModel = new PageObjectViewModel(_dialogServiceMock.Object);
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/PageObjectViewModelTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/PageObjectViewModelTests.cs
@@ -1,0 +1,21 @@
+using Testura.Android.PageObjectCreator.ViewModels;
+using NUnit.Framework;
+using Testura.Android.PageObjectCreator.Services;
+using Moq;
+
+namespace Testura.Android.PageObjectCreator.Tests.ViewModels
+{
+    [TestFixture]
+    public class PageObjectViewModelTests
+    {
+        private Mock<IDialogService> dialogServiceMock;
+        private PageObjectViewModel pageObjectViewModel;
+
+        [SetUp]
+        public void SetUp()
+        {
+            dialogServiceMock = new Mock<IDialogService>();
+            pageObjectViewModel = new PageObjectViewModel(dialogServiceMock.Object);
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/ScreenViewModelTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/ScreenViewModelTests.cs
@@ -11,6 +11,7 @@ namespace Testura.Android.PageObjectCreator.Tests.ViewModels
         private Mock<IFileService> fileServiceMock;
         private Mock<IScreenService> screenServiceMock;
         private Mock<IDialogService> dialogServiceMock;
+        private Mock<IOptimalWithService> _optimalWithServiceMock; 
         private ScreenViewModel screenViewModel;
 
         [SetUp]
@@ -19,7 +20,8 @@ namespace Testura.Android.PageObjectCreator.Tests.ViewModels
             fileServiceMock = new Mock<IFileService>();
             screenServiceMock = new Mock<IScreenService>();
             dialogServiceMock = new Mock<IDialogService>();
-            screenViewModel = new ScreenViewModel(fileServiceMock.Object, screenServiceMock.Object, dialogServiceMock.Object);
+            _optimalWithServiceMock = new Mock<IOptimalWithService>();
+            screenViewModel = new ScreenViewModel(fileServiceMock.Object, screenServiceMock.Object, dialogServiceMock.Object, _optimalWithServiceMock.Object);
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/ScreenViewModelTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/ScreenViewModelTests.cs
@@ -8,20 +8,18 @@ namespace Testura.Android.PageObjectCreator.Tests.ViewModels
     [TestFixture]
     public class ScreenViewModelTests
     {
-        private Mock<IFileService> fileServiceMock;
-        private Mock<IScreenService> screenServiceMock;
-        private Mock<IDialogService> dialogServiceMock;
-        private Mock<IOptimalWithService> _optimalWithServiceMock; 
-        private ScreenViewModel screenViewModel;
+        private Mock<IScreenService> _screenServiceMock;
+        private Mock<IDialogService> _dialogServiceMock;
+        private Mock<IAutoSelectedWithFinderService> _optimalWithServiceMock; 
+        private ScreenViewModel _screenViewModel;
 
         [SetUp]
         public void SetUp()
         {
-            fileServiceMock = new Mock<IFileService>();
-            screenServiceMock = new Mock<IScreenService>();
-            dialogServiceMock = new Mock<IDialogService>();
-            _optimalWithServiceMock = new Mock<IOptimalWithService>();
-            screenViewModel = new ScreenViewModel(fileServiceMock.Object, screenServiceMock.Object, dialogServiceMock.Object, _optimalWithServiceMock.Object);
+            _screenServiceMock = new Mock<IScreenService>();
+            _dialogServiceMock = new Mock<IDialogService>();
+            _optimalWithServiceMock = new Mock<IAutoSelectedWithFinderService>();
+            _screenViewModel = new ScreenViewModel(_screenServiceMock.Object, _dialogServiceMock.Object, _optimalWithServiceMock.Object);
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/ScreenViewModelTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/ScreenViewModelTests.cs
@@ -10,7 +10,7 @@ namespace Testura.Android.PageObjectCreator.Tests.ViewModels
     {
         private Mock<IScreenService> _screenServiceMock;
         private Mock<IDialogService> _dialogServiceMock;
-        private Mock<IAutoSelectedWithFinderService> _optimalWithServiceMock; 
+        private Mock<IUniqueWithFinderService> _optimalWithServiceMock; 
         private ScreenViewModel _screenViewModel;
 
         [SetUp]
@@ -18,7 +18,7 @@ namespace Testura.Android.PageObjectCreator.Tests.ViewModels
         {
             _screenServiceMock = new Mock<IScreenService>();
             _dialogServiceMock = new Mock<IDialogService>();
-            _optimalWithServiceMock = new Mock<IAutoSelectedWithFinderService>();
+            _optimalWithServiceMock = new Mock<IUniqueWithFinderService>();
             _screenViewModel = new ScreenViewModel(_screenServiceMock.Object, _dialogServiceMock.Object, _optimalWithServiceMock.Object);
         }
     }

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/ScreenViewModelTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/ScreenViewModelTests.cs
@@ -1,0 +1,25 @@
+using Testura.Android.PageObjectCreator.ViewModels;
+using NUnit.Framework;
+using Testura.Android.PageObjectCreator.Services;
+using Moq;
+
+namespace Testura.Android.PageObjectCreator.Tests.ViewModels
+{
+    [TestFixture]
+    public class ScreenViewModelTests
+    {
+        private Mock<IFileService> fileServiceMock;
+        private Mock<IScreenService> screenServiceMock;
+        private Mock<IDialogService> dialogServiceMock;
+        private ScreenViewModel screenViewModel;
+
+        [SetUp]
+        public void SetUp()
+        {
+            fileServiceMock = new Mock<IFileService>();
+            screenServiceMock = new Mock<IScreenService>();
+            dialogServiceMock = new Mock<IDialogService>();
+            screenViewModel = new ScreenViewModel(fileServiceMock.Object, screenServiceMock.Object, dialogServiceMock.Object);
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/ViewModelLocatorTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/ViewModelLocatorTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.ViewModels;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.ViewModels
+{
+    [TestFixture]
+    public class ViewModelLocatorTests
+    {
+        private ViewModelLocator viewModelLocator;
+
+        [SetUp]
+        public void SetUp()
+        {
+            viewModelLocator = new ViewModelLocator();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/ViewModelLocatorTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/ViewModelLocatorTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.ViewModels
     [TestFixture]
     public class ViewModelLocatorTests
     {
-        private ViewModelLocator viewModelLocator;
+        private ViewModelLocator _viewModelLocator;
 
         [SetUp]
         public void SetUp()
         {
-            viewModelLocator = new ViewModelLocator();
+            _viewModelLocator = new ViewModelLocator();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/WithViewModelTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/WithViewModelTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.ViewModels;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.ViewModels
+{
+    [TestFixture]
+    public class WithViewModelTests
+    {
+        private WithViewModel withViewModel;
+
+        [SetUp]
+        public void SetUp()
+        {
+            withViewModel = new WithViewModel();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/WithViewModelTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/WithViewModelTests.cs
@@ -1,17 +1,21 @@
+using Moq;
 using Testura.Android.PageObjectCreator.ViewModels;
 using NUnit.Framework;
+using Testura.Android.PageObjectCreator.Services;
 
 namespace Testura.Android.PageObjectCreator.Tests.ViewModels
 {
     [TestFixture]
     public class WithViewModelTests
     {
+        private Mock<IOptimalWithService> _optimalWithServiceMock;
         private WithViewModel withViewModel;
 
         [SetUp]
         public void SetUp()
         {
-            withViewModel = new WithViewModel();
+            _optimalWithServiceMock = new Mock<IOptimalWithService>();
+            withViewModel = new WithViewModel(_optimalWithServiceMock.Object);
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/WithViewModelTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/WithViewModelTests.cs
@@ -8,14 +8,14 @@ namespace Testura.Android.PageObjectCreator.Tests.ViewModels
     [TestFixture]
     public class WithViewModelTests
     {
-        private Mock<IOptimalWithService> _optimalWithServiceMock;
-        private WithViewModel withViewModel;
+        private Mock<IAutoSelectedWithFinderService> _optimalWithServiceMock;
+        private WithViewModel _withViewModel;
 
         [SetUp]
         public void SetUp()
         {
-            _optimalWithServiceMock = new Mock<IOptimalWithService>();
-            withViewModel = new WithViewModel(_optimalWithServiceMock.Object);
+            _optimalWithServiceMock = new Mock<IAutoSelectedWithFinderService>();
+            _withViewModel = new WithViewModel(_optimalWithServiceMock.Object);
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/ViewModels/WithViewModelTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/ViewModels/WithViewModelTests.cs
@@ -8,13 +8,13 @@ namespace Testura.Android.PageObjectCreator.Tests.ViewModels
     [TestFixture]
     public class WithViewModelTests
     {
-        private Mock<IAutoSelectedWithFinderService> _optimalWithServiceMock;
+        private Mock<IUniqueWithFinderService> _optimalWithServiceMock;
         private WithViewModel _withViewModel;
 
         [SetUp]
         public void SetUp()
         {
-            _optimalWithServiceMock = new Mock<IAutoSelectedWithFinderService>();
+            _optimalWithServiceMock = new Mock<IUniqueWithFinderService>();
             _withViewModel = new WithViewModel(_optimalWithServiceMock.Object);
         }
     }

--- a/src/Testura.Android.PageObjectCreator.Tests/Views/CodeViewTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Views/CodeViewTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Views
     [TestFixture]
     public class CodeViewTests
     {
-        private CodeView codeView;
+        private CodeView _codeView;
 
         [SetUp]
         public void SetUp()
         {
-            codeView = new CodeView();
+            _codeView = new CodeView();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Views/CodeViewTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Views/CodeViewTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Views;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Views
+{
+    [TestFixture]
+    public class CodeViewTests
+    {
+        private CodeView codeView;
+
+        [SetUp]
+        public void SetUp()
+        {
+            codeView = new CodeView();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Views/DeviceViewTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Views/DeviceViewTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Views
     [TestFixture]
     public class DeviceViewTests
     {
-        private DeviceView deviceView;
+        private DeviceView _deviceView;
 
         [SetUp]
         public void SetUp()
         {
-            deviceView = new DeviceView();
+            _deviceView = new DeviceView();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Views/DeviceViewTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Views/DeviceViewTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Views;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Views
+{
+    [TestFixture]
+    public class DeviceViewTests
+    {
+        private DeviceView deviceView;
+
+        [SetUp]
+        public void SetUp()
+        {
+            deviceView = new DeviceView();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Views/HierarchyViewTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Views/HierarchyViewTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Views;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Views
+{
+    [TestFixture]
+    public class HierarchyViewTests
+    {
+        private HierarchyView hierarchyView;
+
+        [SetUp]
+        public void SetUp()
+        {
+            hierarchyView = new HierarchyView();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Views/HierarchyViewTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Views/HierarchyViewTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Views
     [TestFixture]
     public class HierarchyViewTests
     {
-        private HierarchyView hierarchyView;
+        private HierarchyView _hierarchyView;
 
         [SetUp]
         public void SetUp()
         {
-            hierarchyView = new HierarchyView();
+            _hierarchyView = new HierarchyView();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Views/OperationViewTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Views/OperationViewTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Views;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Views
+{
+    [TestFixture]
+    public class OperationViewTests
+    {
+        private OperationView operationView;
+
+        [SetUp]
+        public void SetUp()
+        {
+            operationView = new OperationView();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Views/OperationViewTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Views/OperationViewTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Views
     [TestFixture]
     public class OperationViewTests
     {
-        private OperationView operationView;
+        private OperationView _operationView;
 
         [SetUp]
         public void SetUp()
         {
-            operationView = new OperationView();
+            _operationView = new OperationView();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Views/PageObjectViewTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Views/PageObjectViewTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Views
     [TestFixture]
     public class PageObjectViewTests
     {
-        private PageObjectView pageObjectView;
+        private PageObjectView _pageObjectView;
 
         [SetUp]
         public void SetUp()
         {
-            pageObjectView = new PageObjectView();
+            _pageObjectView = new PageObjectView();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Views/PageObjectViewTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Views/PageObjectViewTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Views;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Views
+{
+    [TestFixture]
+    public class PageObjectViewTests
+    {
+        private PageObjectView pageObjectView;
+
+        [SetUp]
+        public void SetUp()
+        {
+            pageObjectView = new PageObjectView();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/Views/ScreenViewTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Views/ScreenViewTests.cs
@@ -6,12 +6,12 @@ namespace Testura.Android.PageObjectCreator.Tests.Views
     [TestFixture]
     public class ScreenViewTests
     {
-        private ScreenView screenView;
+        private ScreenView _screenView;
 
         [SetUp]
         public void SetUp()
         {
-            screenView = new ScreenView();
+            _screenView = new ScreenView();
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator.Tests/Views/ScreenViewTests.cs
+++ b/src/Testura.Android.PageObjectCreator.Tests/Views/ScreenViewTests.cs
@@ -1,0 +1,17 @@
+using Testura.Android.PageObjectCreator.Views;
+using NUnit.Framework;
+
+namespace Testura.Android.PageObjectCreator.Tests.Views
+{
+    [TestFixture]
+    public class ScreenViewTests
+    {
+        private ScreenView screenView;
+
+        [SetUp]
+        public void SetUp()
+        {
+            screenView = new ScreenView();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator.Tests/packages.config
+++ b/src/Testura.Android.PageObjectCreator.Tests/packages.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Castle.Core" version="4.0.0" targetFramework="net452" />
+  <package id="Moq" version="4.7.1" targetFramework="net452" />
+  <package id="MSTest.TestAdapter" version="1.1.8-rc2" targetFramework="net452" />
+  <package id="MSTest.TestFramework" version="1.0.8-rc2" targetFramework="net452" />
+  <package id="NUnit" version="3.6.1" targetFramework="net452" />
+  <package id="NUnit3TestAdapter" version="3.7.0" targetFramework="net452" />
+</packages>

--- a/src/Testura.Android.PageObjectCreator.Tests/packages.config
+++ b/src/Testura.Android.PageObjectCreator.Tests/packages.config
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.0.0" targetFramework="net452" />
+  <package id="MedallionShell" version="1.2.1" targetFramework="net452" />
   <package id="Moq" version="4.7.1" targetFramework="net452" />
   <package id="MSTest.TestAdapter" version="1.1.8-rc2" targetFramework="net452" />
   <package id="MSTest.TestFramework" version="1.0.8-rc2" targetFramework="net452" />
   <package id="NUnit" version="3.6.1" targetFramework="net452" />
   <package id="NUnit3TestAdapter" version="3.7.0" targetFramework="net452" />
+  <package id="Testura.Android" version="0.9.2" targetFramework="net452" />
 </packages>

--- a/src/Testura.Android.PageObjectCreator/Dialogs/ClearDialog.xaml
+++ b/src/Testura.Android.PageObjectCreator/Dialogs/ClearDialog.xaml
@@ -1,0 +1,36 @@
+﻿<controls:MetroWindow x:Class="Testura.Android.PageObjectCreator.Dialogs.ClearDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Testura.Android.PageObjectCreator.Dialogs"
+        xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls"
+        mc:Ignorable="d"
+        Title="Clear UiObjects" Height="135" Width="400"
+        SizeToContent="WidthAndHeight"
+        ResizeMode="NoResize"
+        GlowBrush="{DynamicResource AccentColorBrush}"
+        Icon="{StaticResource MainIcon}"
+        WindowStartupLocation="CenterScreen">
+    <controls:MetroWindow.IconTemplate>
+        <DataTemplate>
+            <Image Source="{StaticResource MainIcon}"
+                   Width="20"></Image>
+        </DataTemplate>
+    </controls:MetroWindow.IconTemplate>
+    <Grid>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="40" />
+            </Grid.RowDefinitions>
+            <Label Content="You have existing UiObjects, should we clear them?" Grid.Row="0" Margin="15"/>
+            <StackPanel Orientation="Horizontal" Grid.Row="1" Margin="0, 0, 10, 10" HorizontalAlignment="Right">
+                <Button Content="Yes" x:Name="YesButton" Grid.Row="1" HorizontalAlignment="Right" Margin="0, 0, 10, 0" Click="YesButtonClick" Width="75" Height="25"/>
+                <Button Content="No" x:Name="NoButton" Grid.Row="1" HorizontalAlignment="Right" Margin="0, 0, 10, 0" Click="NoButtonClick" Width="75" Height="25"/>
+            </StackPanel>
+            
+        </Grid>
+    </Grid>
+</controls:MetroWindow>
+

--- a/src/Testura.Android.PageObjectCreator/Dialogs/ClearDialog.xaml.cs
+++ b/src/Testura.Android.PageObjectCreator/Dialogs/ClearDialog.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System.Windows;
+using MahApps.Metro.Controls;
+
+namespace Testura.Android.PageObjectCreator.Dialogs
+{
+    /// <summary>
+    /// Interaction logic for ClearDialog.xaml
+    /// </summary>
+    public partial class ClearDialog : MetroWindow
+    {
+        public ClearDialog()
+        {
+            InitializeComponent();
+        }
+
+        private void YesButtonClick(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+            Close();
+        }
+
+        private void NoButtonClick(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator/Dialogs/WithDialog.xaml
+++ b/src/Testura.Android.PageObjectCreator/Dialogs/WithDialog.xaml
@@ -6,7 +6,7 @@
                        xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls"
         mc:Ignorable="d"
         TitleCharacterCasing="Normal"
-        Title="Select Withs" Height="345" Width="575"
+        Title="Select Withs" Height="365" Width="575"
         GlowBrush="{DynamicResource AccentColorBrush}"
         Icon="{StaticResource MainIcon}" WindowStartupLocation="CenterScreen"
         DataContext="{Binding Source={StaticResource Locator}, Path=WithViewModel}"
@@ -32,7 +32,8 @@
                     </Grid.ColumnDefinitions>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="34"/>
-                        <RowDefinition Height="*"></RowDefinition>
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="20" />
                     </Grid.RowDefinitions>
                     <Label Content="Select not with"
                            Foreground="White"
@@ -53,7 +54,8 @@
                     <StackPanel Grid.Column="1"
                                 Grid.Row="1"
                                 Margin="0, 10, 0, 0"
-                                VerticalAlignment="Center">
+                                VerticalAlignment="Center"
+                                IsEnabled="{Binding UseUniqueWiths, Converter={StaticResource InvertBoolConverter}}">
                         <Button Content="&gt;&gt;"
                                 Command="{Binding AddCommand}"
                                 CommandParameter="{Binding SelectedItem, ElementName=NotUsedList}"
@@ -78,6 +80,7 @@
                                   Background="{StaticResource WindowBackgroundColorBrush}"
                                   x:Name="UsedList" />
                     </Border>
+                    <CheckBox Content="Automatically select unique withs" Grid.Row="2" Margin="10, 0, 0, 0" IsChecked="{Binding UseUniqueWiths}" />
                 </Grid>
             </TabItem>
             <TabItem Header="Node details">

--- a/src/Testura.Android.PageObjectCreator/Dialogs/WithDialog.xaml.cs
+++ b/src/Testura.Android.PageObjectCreator/Dialogs/WithDialog.xaml.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using MahApps.Metro.Controls;
+using Testura.Android.Device.Ui.Nodes.Data;
 using Testura.Android.PageObjectCreator.Models;
 using Testura.Android.PageObjectCreator.ViewModels;
 
@@ -10,11 +12,11 @@ namespace Testura.Android.PageObjectCreator.Dialogs
     /// </summary>
     public partial class WithDialog : MetroWindow
     {
-        public WithDialog(UiObjectInfo uiObjectInfo)
+        public WithDialog(UiObjectInfo uiObjectInfo, IList<Node> nodes)
         {
             InitializeComponent();
             var viewModel = DataContext as WithViewModel;
-            viewModel.SetCurrentUiObjectInfo(uiObjectInfo);
+            viewModel.SetCurrentUiObjectInfo(uiObjectInfo, nodes);
             viewModel.CloseWindow += CloseWindow;
         }
 

--- a/src/Testura.Android.PageObjectCreator/MainWindow.xaml
+++ b/src/Testura.Android.PageObjectCreator/MainWindow.xaml
@@ -6,7 +6,7 @@
                       xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls"
                       xmlns:views="clr-namespace:Testura.Android.PageObjectCreator.Views"
                       mc:Ignorable="d"
-        Title="Testura - Page object generator" Height="350" Width="525"
+        Title="Testura - Page object creator" Height="350" Width="525"
         DataContext="{Binding Source={StaticResource Locator}, Path=MainViewModel}"
         TitleCharacterCasing="Normal"
         GlowBrush="{DynamicResource AccentColorBrush}"

--- a/src/Testura.Android.PageObjectCreator/MainWindow.xaml
+++ b/src/Testura.Android.PageObjectCreator/MainWindow.xaml
@@ -72,11 +72,11 @@
                        Grid.Row="0"
                        Grid.Column="0" />
                 <TabControl Grid.Row="1" Margin="5, 0, 5, 0" Visibility="{Binding IsEditEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <TabItem Header="Page object">
-                        <views:PageObjectView />
-                    </TabItem>
                     <TabItem Header="Hierarchy">
                         <views:HierarchyView />
+                    </TabItem>
+                    <TabItem Header="Page object">
+                        <views:PageObjectView />
                     </TabItem>
                     <TabItem Header="Code">
                         <views:CodeView />

--- a/src/Testura.Android.PageObjectCreator/Models/AutoSelectedWith.cs
+++ b/src/Testura.Android.PageObjectCreator/Models/AutoSelectedWith.cs
@@ -4,12 +4,12 @@ using Testura.Android.Util;
 
 namespace Testura.Android.PageObjectCreator.Models
 {
-    public class OptimalWith
+    public class AutoSelectedWith
     {
         public Node Node { get; set; }
 
         public IList<AttributeTags> Withs { get; set; }
 
-        public OptimalWith Parent { get; set; }
+        public AutoSelectedWith Parent { get; set; }
     }
 }

--- a/src/Testura.Android.PageObjectCreator/Models/Messages/DumpMessage.cs
+++ b/src/Testura.Android.PageObjectCreator/Models/Messages/DumpMessage.cs
@@ -1,4 +1,6 @@
-﻿namespace Testura.Android.PageObjectCreator.Models.Messages
+﻿using Testura.Android.Device.Ui.Nodes.Data;
+
+namespace Testura.Android.PageObjectCreator.Models.Messages
 {
     /// <summary>
     /// Message sent after a screen dump
@@ -6,5 +8,7 @@
     public class DumpMessage
     {
         public AndroidDumpInfo DumpInfo { get; set; }
+
+        public Node Node { get; set; }
     }
 }

--- a/src/Testura.Android.PageObjectCreator/Models/Messages/DumpMessage.cs
+++ b/src/Testura.Android.PageObjectCreator/Models/Messages/DumpMessage.cs
@@ -9,6 +9,6 @@ namespace Testura.Android.PageObjectCreator.Models.Messages
     {
         public AndroidDumpInfo DumpInfo { get; set; }
 
-        public Node Node { get; set; }
+        public Node TopNode { get; set; }
     }
 }

--- a/src/Testura.Android.PageObjectCreator/Models/NodeTreeItem.cs
+++ b/src/Testura.Android.PageObjectCreator/Models/NodeTreeItem.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.ObjectModel;
+using System.Linq;
+using PropertyChanged;
+using Testura.Android.Device.Ui.Nodes.Data;
+
+namespace Testura.Android.PageObjectCreator.Models
+{
+    [ImplementPropertyChanged]
+    public class NodeTreeItem
+    {
+        public NodeTreeItem(Node node)
+        {
+            Node = node;
+            Children = new ObservableCollection<NodeTreeItem>(Node.Children.Select(n => new NodeTreeItem(n)));
+        }
+
+        public Node Node { get; set; }
+
+        public ObservableCollection<NodeTreeItem> Children { get; set; }
+
+        public bool IsSelected { get; set; }
+
+        public bool IsExpanded { get; set; }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator/Models/OptimalWith.cs
+++ b/src/Testura.Android.PageObjectCreator/Models/OptimalWith.cs
@@ -1,10 +1,13 @@
 ﻿using System.Collections.Generic;
+using Testura.Android.Device.Ui.Nodes.Data;
 using Testura.Android.Util;
 
 namespace Testura.Android.PageObjectCreator.Models
 {
     public class OptimalWith
     {
+        public Node Node { get; set; }
+
         public IList<AttributeTags> Withs { get; set; }
 
         public OptimalWith Parent { get; set; }

--- a/src/Testura.Android.PageObjectCreator/Models/OptimalWith.cs
+++ b/src/Testura.Android.PageObjectCreator/Models/OptimalWith.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using Testura.Android.Util;
+
+namespace Testura.Android.PageObjectCreator.Models
+{
+    public class OptimalWith
+    {
+        public IList<AttributeTags> Withs { get; set; }
+
+        public OptimalWith Parent { get; set; }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator/Models/UiObjectInfo.cs
+++ b/src/Testura.Android.PageObjectCreator/Models/UiObjectInfo.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using PropertyChanged;
 using Testura.Android.Device.Ui.Nodes.Data;
 using Testura.Android.Util;
@@ -26,44 +24,21 @@ namespace Testura.Android.PageObjectCreator.Models
         public IList<AttributeTags> FindWith { get; set; }
 
         /// <summary>
-        /// Gets or sets the optimal with
+        /// Gets or sets the auto selected with
         /// </summary>
-        public OptimalWith Optimal { get; set; }
+        public AutoSelectedWith AutoSelectedWith { get; set; }
 
         /// <summary>
         /// Gets or sets the find string that contains all our selected withs
         /// </summary>
-        public string FindWithString { get; set; }
+        public string DisplayName { get; set; }
 
         /// <summary>
-        /// Get the correct property data by FindBY
+        /// Update the display name
         /// </summary>
-        /// <returns>Correct property data</returns>
-        public string GetFindBy()
+        public void UpdateDisplayName()
         {
-            var stringBuilder = new StringBuilder();
-            foreach (var attributeTagse in FindWith)
-            {
-                switch (attributeTagse)
-                {
-                    case AttributeTags.ResourceId:
-                        stringBuilder.Append($"ResourceId={Node.ResourceId},");
-                        break;
-
-                    case AttributeTags.ContentDesc:
-                        stringBuilder.Append($"ContentDesc={Node.ContentDesc},");
-                        break;
-
-                    case AttributeTags.Text:
-                        stringBuilder.Append($"Text={Node.Text},");
-                        break;
-
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
-            }
-
-            return stringBuilder.Remove(stringBuilder.Length - 1, 1).ToString();
+            DisplayName = AutoSelectedWith != null ? "Automatic" : string.Join(", ", FindWith);
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator/Models/UiObjectInfo.cs
+++ b/src/Testura.Android.PageObjectCreator/Models/UiObjectInfo.cs
@@ -41,11 +41,6 @@ namespace Testura.Android.PageObjectCreator.Models
         /// <returns>Correct property data</returns>
         public string GetFindBy()
         {
-            if (Optimal != null)
-            {
-                return "Optimal";
-            }
-
             var stringBuilder = new StringBuilder();
             foreach (var attributeTagse in FindWith)
             {

--- a/src/Testura.Android.PageObjectCreator/Models/UiObjectInfo.cs
+++ b/src/Testura.Android.PageObjectCreator/Models/UiObjectInfo.cs
@@ -26,6 +26,11 @@ namespace Testura.Android.PageObjectCreator.Models
         public IList<AttributeTags> FindWith { get; set; }
 
         /// <summary>
+        /// Gets or sets the optimal with
+        /// </summary>
+        public OptimalWith Optimal { get; set; }
+
+        /// <summary>
         /// Gets or sets the find string that contains all our selected withs
         /// </summary>
         public string FindWithString { get; set; }
@@ -36,6 +41,11 @@ namespace Testura.Android.PageObjectCreator.Models
         /// <returns>Correct property data</returns>
         public string GetFindBy()
         {
+            if (Optimal != null)
+            {
+                return "Optimal";
+            }
+
             var stringBuilder = new StringBuilder();
             foreach (var attributeTagse in FindWith)
             {

--- a/src/Testura.Android.PageObjectCreator/Properties/AssemblyInfo.cs
+++ b/src/Testura.Android.PageObjectCreator/Properties/AssemblyInfo.cs
@@ -39,5 +39,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.1.0")]
-[assembly: AssemblyFileVersion("1.1.1.0")]
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]

--- a/src/Testura.Android.PageObjectCreator/Services/CodeService.cs
+++ b/src/Testura.Android.PageObjectCreator/Services/CodeService.cs
@@ -1,0 +1,210 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Testura.Android.Device;
+using Testura.Android.Device.Ui.Nodes.Data;
+using Testura.Android.Device.Ui.Objects;
+using Testura.Android.PageObjectCreator.Models;
+using Testura.Android.Util;
+using Testura.Code;
+using Testura.Code.Builders;
+using Testura.Code.Generators.Class;
+using Testura.Code.Generators.Common;
+using Testura.Code.Generators.Common.Arguments.ArgumentTypes;
+using Testura.Code.Generators.Common.BinaryExpressions;
+using Testura.Code.Models;
+using Testura.Code.Models.References;
+using Testura.Code.Saver;
+using Testura.Code.Statements;
+
+namespace Testura.Android.PageObjectCreator.Services
+{
+    public class CodeService : ICodeService
+    {
+        private const string DeviceName = "device";
+        private CodeSaver _codeSaver;
+
+        public CodeService()
+        {
+            _codeSaver = new CodeSaver();
+        }
+
+        public string GeneratePageObject(string pageObejctName, string @namespace, IEnumerable<UiObjectInfo> uiObjects)
+        {
+            var fields = new List<Field>();
+            var statements = new List<StatementSyntax>();
+
+            fields.Add(new Field(DeviceName, typeof(IAndroidDevice), new[] {Modifiers.Private}));
+            statements.Add(Statement.Declaration.Assign(new VariableReference("this", new MemberReference(DeviceName)),
+                new VariableReference("device")));
+
+            foreach (var pageObjectUiNode in uiObjects)
+            {
+                GenerateUiObject(fields, statements, pageObjectUiNode);
+            }
+
+            var classBuilder = new ClassBuilder(pageObejctName, @namespace)
+                .WithUsings("Testura.Android.Device", "Testura.Android.Device.Ui.Objects",
+                    "Testura.Android.Device.Ui.Search")
+                .WithFields(fields.ToArray())
+                .WithConstructor(ConstructorGenerator.Create(pageObejctName,
+                    BodyGenerator.Create(statements.ToArray()), modifiers: new[] {Modifiers.Public},
+                    parameters: new List<Parameter> {new Parameter("device", typeof(IAndroidDevice))}))
+                .Build();
+            return _codeSaver.SaveCodeAsString(classBuilder);
+        }
+
+        private void GenerateUiObject(List<Field> fields, List<StatementSyntax> statements,
+            UiObjectInfo pageObjectUiNode)
+        {
+            fields.Add(new Field(pageObjectUiNode.Name, typeof(UiObject), new[] {Modifiers.Private}));
+            statements.Add(Statement.Declaration.Assign(pageObjectUiNode.Name,
+                new VariableReference(DeviceName,
+                    new MemberReference("Ui",
+                        new MethodReference("CreateUiObject", GenerateWithArgument(pageObjectUiNode))))));
+        }
+
+        private IEnumerable<IArgument> GenerateWithArgument(UiObjectInfo uiObjectInfo)
+        {
+            var arguments = new List<IArgument>();
+
+            IList<AttributeTags> withs = null;
+
+            if (uiObjectInfo.Optimal != null)
+            {
+                if (uiObjectInfo.Optimal.Parent == null)
+                {
+                    withs = uiObjectInfo.Optimal.Withs;
+                }
+                else
+                {
+                    return GenerateOptimalWiths(uiObjectInfo.Optimal);
+                }
+            }
+            else
+            {
+                withs = uiObjectInfo.FindWith;
+            }
+
+            foreach (var with in withs)
+            {
+                var value = GetNodeValue(uiObjectInfo.Node, with);
+                ValueArgument valueArgument;
+                if (with == AttributeTags.Index)
+                {
+                    valueArgument = new ValueArgument(int.Parse(value));
+                }
+                else
+                {
+                    valueArgument = new ValueArgument(value);
+                }
+
+                arguments.Add(
+                    new ReferenceArgument(new VariableReference("With",
+                        new MethodReference(with.ToString(), new[] {valueArgument}))));
+            }
+
+            return arguments;
+        }
+
+        private IEnumerable<IArgument> GenerateOptimalWiths(OptimalWith optimal)
+        {
+            if (optimal.Parent.Parent == null)
+            {
+                return new List<IArgument>
+                {
+                    new LambdaArgument(
+                        new AndBinaryExpression(GetBinaryExpression(optimal.Parent, true, 1),
+                            GetBinaryExpression(optimal, false, 0)).GetBinaryExpression(), "n")
+                };
+            }
+
+
+
+            var mainIf = Statement.Selection.If(GetBinaryExpression(optimal, false, 0),
+                BodyGenerator.Create(Statement.Jump.ReturnTrue()));
+
+            return new List<IArgument>
+            {
+                new LambdaArgument(BodyGenerator.Create(GenerateParantIfs(optimal.Parent, mainIf, 1), Statement.Jump.ReturnFalse()), "n")
+            };
+        }
+
+        private StatementSyntax GenerateParantIfs(OptimalWith optimalWith, StatementSyntax child, int depth)
+        {
+            var myIf = Statement.Selection.If(GetBinaryExpression(optimalWith, true, depth), BodyGenerator.Create(child));
+
+            if (optimalWith.Parent != null)
+            {
+                return GenerateParantIfs(optimalWith.Parent, myIf, depth + 1);
+            }
+
+            return myIf;
+        }
+
+        private IBinaryExpression GetBinaryExpression(OptimalWith optimal, bool isParent, int depth)
+        {
+            var binaryExpressions = new List<ConditionalBinaryExpression>();
+
+
+            foreach (var attributeTagse in optimal.Withs)
+            {
+                var leftReference = new VariableReference("n", new MemberReference(Enum.GetName(typeof(AttributeTags), attributeTagse)));
+                if (isParent)
+                {
+                    var name = new StringBuilder();
+                    for (int n = 0; n < depth; n++)
+                    {
+                        name.Append("Parent?.");
+                    }
+
+                    name = name.Remove(name.Length - 1, 1);
+
+                    leftReference = new VariableReference("n",
+    new MemberReference(name.ToString(),
+        new MemberReference(Enum.GetName(typeof(AttributeTags), attributeTagse))));
+                }
+
+
+                binaryExpressions.Add(new ConditionalBinaryExpression(leftReference,
+                    new ConstantReference(GetNodeValue(optimal.Node, attributeTagse)), ConditionalStatements.Equal));
+            }
+
+            IBinaryExpression finalBinaryExpression = null;
+
+            if (binaryExpressions.Count > 1)
+            {
+                finalBinaryExpression = new AndBinaryExpression(binaryExpressions.First(), binaryExpressions.Last());
+            }
+            else
+            {
+                finalBinaryExpression = binaryExpressions.First();
+            }
+
+            return finalBinaryExpression;
+        }
+
+        private string GetNodeValue(Node node, AttributeTags with)
+        {
+            switch (with)
+            {
+                case AttributeTags.Text:
+                    return node.Text;
+                case AttributeTags.ResourceId:
+                    return node.ResourceId;
+                case AttributeTags.ContentDesc:
+                    return node.ContentDesc;
+                case AttributeTags.Class:
+                    return node.Class;
+                case AttributeTags.Package:
+                    return node.Package;
+                case AttributeTags.Index:
+                    return node.Index;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(with), with, null);
+            }
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator/Services/DialogService.cs
+++ b/src/Testura.Android.PageObjectCreator/Services/DialogService.cs
@@ -45,5 +45,11 @@ namespace Testura.Android.PageObjectCreator.Services
            var dialog = new AboutDialog();
             dialog.ShowDialog();
         }
+
+        public bool ShowClearUiObjectsDialog()
+        {
+            var dialog = new ClearDialog();
+            return dialog.ShowDialog().Value;
+        }
     }
 }

--- a/src/Testura.Android.PageObjectCreator/Services/DialogService.cs
+++ b/src/Testura.Android.PageObjectCreator/Services/DialogService.cs
@@ -1,4 +1,6 @@
-﻿using Testura.Android.PageObjectCreator.Dialogs;
+﻿using System.Collections.Generic;
+using Testura.Android.Device.Ui.Nodes.Data;
+using Testura.Android.PageObjectCreator.Dialogs;
 using Testura.Android.PageObjectCreator.Models;
 
 namespace Testura.Android.PageObjectCreator.Services
@@ -19,9 +21,9 @@ namespace Testura.Android.PageObjectCreator.Services
         /// Show the edit with dialog
         /// </summary>
         /// <param name="uiObjectInfo">UiObjected to edit withs for</param>
-        public void ShowWithDialog(UiObjectInfo uiObjectInfo)
+        public void ShowWithDialog(UiObjectInfo uiObjectInfo, IList<Node> nodes)
         {
-            var dialog = new WithDialog(uiObjectInfo);
+            var dialog = new WithDialog(uiObjectInfo, nodes);
             dialog.ShowDialog();
         }
 

--- a/src/Testura.Android.PageObjectCreator/Services/IAutoSelectedWithFinderService.cs
+++ b/src/Testura.Android.PageObjectCreator/Services/IAutoSelectedWithFinderService.cs
@@ -4,8 +4,8 @@ using Testura.Android.PageObjectCreator.Models;
 
 namespace Testura.Android.PageObjectCreator.Services
 {
-    public interface IOptimalWithService
+    public interface IAutoSelectedWithFinderService
     {
-        OptimalWith GetOptimalWith(Node selectedNode, IList<Node> allNode);
+        AutoSelectedWith GetUniqueWiths(Node selectedNode, IList<Node> allNode);
     }
 }

--- a/src/Testura.Android.PageObjectCreator/Services/ICodeService.cs
+++ b/src/Testura.Android.PageObjectCreator/Services/ICodeService.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using Testura.Android.PageObjectCreator.Models;
+
+namespace Testura.Android.PageObjectCreator.Services
+{
+    public interface ICodeService
+    {
+        /// <summary>
+        /// Generate the class, fields and constructor for a page object
+        /// </summary>
+        /// <param name="pageObejctName">Name of the new page object</param>
+        /// <param name="namespace">Name of the namespace to generate</param>
+        /// <param name="uiObjects">UiObject inside the class</param>
+        /// <returns>The generated code as a string</returns>
+        string GeneratePageObject(string pageObejctName, string @namespace, IEnumerable<UiObjectInfo> uiObjects);
+    }
+}

--- a/src/Testura.Android.PageObjectCreator/Services/IDialogService.cs
+++ b/src/Testura.Android.PageObjectCreator/Services/IDialogService.cs
@@ -1,4 +1,6 @@
-﻿using Testura.Android.PageObjectCreator.Models;
+﻿using System.Collections.Generic;
+using Testura.Android.Device.Ui.Nodes.Data;
+using Testura.Android.PageObjectCreator.Models;
 
 namespace Testura.Android.PageObjectCreator.Services
 {
@@ -14,7 +16,7 @@ namespace Testura.Android.PageObjectCreator.Services
         /// Show the edit with dialog
         /// </summary>
         /// <param name="uiObjectInfo">UiObjected to edit withs for</param>
-        void ShowWithDialog(UiObjectInfo uiObjectInfo);
+        void ShowWithDialog(UiObjectInfo uiObjectInfo, IList<Node> nodes);
 
         /// <summary>
         /// Show an error dialog

--- a/src/Testura.Android.PageObjectCreator/Services/IDialogService.cs
+++ b/src/Testura.Android.PageObjectCreator/Services/IDialogService.cs
@@ -28,5 +28,11 @@ namespace Testura.Android.PageObjectCreator.Services
         /// Show the about dialog
         /// </summary>
         void ShowAboutDialog();
+
+        /// <summary>
+        /// Show the clear UiObjects dialog
+        /// </summary>
+        /// <returns></returns>
+        bool ShowClearUiObjectsDialog();
     }
 }

--- a/src/Testura.Android.PageObjectCreator/Services/IOptimalWithService.cs
+++ b/src/Testura.Android.PageObjectCreator/Services/IOptimalWithService.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Testura.Android.Device.Ui.Nodes.Data;
+using Testura.Android.PageObjectCreator.Models;
+
+namespace Testura.Android.PageObjectCreator.Services
+{
+    public interface IOptimalWithService
+    {
+        OptimalWith GetOptimalWith(Node selectedNode, IList<Node> allNode);
+    }
+}

--- a/src/Testura.Android.PageObjectCreator/Services/IScreenService.cs
+++ b/src/Testura.Android.PageObjectCreator/Services/IScreenService.cs
@@ -13,6 +13,6 @@ namespace Testura.Android.PageObjectCreator.Services
         /// <param name="point">Points to check</param>
         /// <param name="dump">the xml dump</param>
         /// <returns>All intersected android elements</returns>
-        IList<Node> GetNodes(Point point, string dump);
+        IList<Node> GetNodes(Point point, Node node);
     }
 }

--- a/src/Testura.Android.PageObjectCreator/Services/IScreenService.cs
+++ b/src/Testura.Android.PageObjectCreator/Services/IScreenService.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Windows;
 using Testura.Android.Device.Ui.Nodes.Data;
-using Testura.Android.PageObjectCreator.Models;
 
 namespace Testura.Android.PageObjectCreator.Services
 {
@@ -11,8 +10,8 @@ namespace Testura.Android.PageObjectCreator.Services
         /// Get all elements that intersect with a point on the screen
         /// </summary>
         /// <param name="point">Points to check</param>
-        /// <param name="dump">the xml dump</param>
+        /// <param name="nodes">All nodes on the dumped screen</param>
         /// <returns>All intersected android elements</returns>
-        IList<Node> GetNodes(Point point, Node node);
+        IList<Node> GetNodes(Point point, IList<Node> nodes);
     }
 }

--- a/src/Testura.Android.PageObjectCreator/Services/IUniqueWithFinderService.cs
+++ b/src/Testura.Android.PageObjectCreator/Services/IUniqueWithFinderService.cs
@@ -4,7 +4,7 @@ using Testura.Android.PageObjectCreator.Models;
 
 namespace Testura.Android.PageObjectCreator.Services
 {
-    public interface IAutoSelectedWithFinderService
+    public interface IUniqueWithFinderService
     {
         AutoSelectedWith GetUniqueWiths(Node selectedNode, IList<Node> allNode);
     }

--- a/src/Testura.Android.PageObjectCreator/Services/OptimalWithService.cs
+++ b/src/Testura.Android.PageObjectCreator/Services/OptimalWithService.cs
@@ -27,6 +27,8 @@ namespace Testura.Android.PageObjectCreator.Services
         public OptimalWith GetOptimalWith(Node selectedNode, IList<Node> allNode)
         {
             var combinations = ItemCombinations(_attributesPriority, 1);
+            combinations.Remove(combinations.FirstOrDefault(c => c.Count == 1 && c.First() == AttributeTags.Text));
+            combinations.Remove(combinations.FirstOrDefault(c => c.Count == 1 && c.First() == AttributeTags.Index));
 
             foreach (var combination in combinations)
             {
@@ -56,14 +58,14 @@ namespace Testura.Android.PageObjectCreator.Services
 
         private bool CheckAttribute(Node node, IList<PropertyInfo> properties, IList<Node> allNodes)
         {
-            if (allNodes.Count == 1)
-            {
-                return true; 
-            }
-
             if (properties.Any(p => string.IsNullOrEmpty(p.GetValue(node)?.ToString())))
             {
                 return false;
+            }
+
+            if (allNodes.Count == 1)
+            {
+                return true;
             }
 
             if (allNodes.Any(n =>
@@ -76,7 +78,7 @@ namespace Testura.Android.PageObjectCreator.Services
                 return properties.All(p =>
                 {
                     var value = p.GetValue(n)?.ToString();
-                    if (value == null)
+                    if (string.IsNullOrEmpty(value))
                     {
                         return false;
                     }

--- a/src/Testura.Android.PageObjectCreator/Services/OptimalWithService.cs
+++ b/src/Testura.Android.PageObjectCreator/Services/OptimalWithService.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Testura.Android.Device.Ui.Nodes.Data;
+using Testura.Android.PageObjectCreator.Models;
+using Testura.Android.Util;
+
+namespace Testura.Android.PageObjectCreator.Services
+{
+    public class OptimalWithService : IOptimalWithService
+    {
+        private readonly IList<AttributeTags> _attributesPriority;
+
+        public OptimalWithService()
+        {
+            _attributesPriority = new List<AttributeTags>
+            {
+                AttributeTags.ResourceId,
+                AttributeTags.ContentDesc,
+                AttributeTags.Text,
+                AttributeTags.Package,
+                AttributeTags.Index
+            };
+        }
+
+        public OptimalWith GetOptimalWith(Node selectedNode, IList<Node> allNode)
+        {
+            var combinations = ItemCombinations(_attributesPriority, 1);
+
+            foreach (var combination in combinations)
+            {
+                var properties = new List<PropertyInfo>();
+
+                foreach (var attributeinfo in combination)
+                {
+                    properties.Add(selectedNode.GetType().GetProperty(Enum.GetName(typeof(AttributeTags), attributeinfo)));
+                }
+
+                if (CheckAttribute(selectedNode, properties, allNode))
+                {
+                    return new OptimalWith {Withs = new List<AttributeTags>(combination)};
+                }
+            }
+
+            if (selectedNode.Parent != null)
+            {
+                var optimalParen = GetOptimalWith(selectedNode.Parent, allNode);
+                var thisOptimalWith = GetOptimalWith(selectedNode, selectedNode.Parent.Children);
+                thisOptimalWith.Parent = optimalParen;
+                return thisOptimalWith;
+            }
+
+            throw new Exception("Failed to find any unique withs");
+        }
+
+        private bool CheckAttribute(Node node, IList<PropertyInfo> properties, IList<Node> allNodes)
+        {
+            if (allNodes.Count == 1)
+            {
+                return true; 
+            }
+
+            if (properties.Any(p => string.IsNullOrEmpty(p.GetValue(node)?.ToString())))
+            {
+                return false;
+            }
+
+            if (allNodes.Any(n =>
+            {
+                if (n == node)
+                {
+                    return false;
+                }
+
+                return properties.All(p =>
+                {
+                    var value = p.GetValue(n)?.ToString();
+                    if (value == null)
+                    {
+                        return false;
+                    }
+
+                    return value.Equals(p.GetValue(node));
+                });
+            }))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private IList<IList<T>> ItemCombinations<T>(IList<T> inputList, int minimumItems = 1)
+        {
+            var nonEmptyCombinations = (int)Math.Pow(2, inputList.Count) - 1;
+            var listOfLists = new List<IList<T>>(nonEmptyCombinations + 1);
+
+            for (int i = 1; i <= nonEmptyCombinations; i++)
+            {
+                var thisCombination = new List<T>();
+                for (int j = 0; j < inputList.Count; j++)
+                {
+                    if ((i >> j & 1) == 1)
+                    {
+                        thisCombination.Add(inputList[j]);
+                    }
+                }
+
+                if (thisCombination.Count >= minimumItems)
+                {
+                    listOfLists.Add(thisCombination);
+                }
+            }
+
+            return listOfLists;
+        }
+    }
+}

--- a/src/Testura.Android.PageObjectCreator/Services/ScreenService.cs
+++ b/src/Testura.Android.PageObjectCreator/Services/ScreenService.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Windows;
 using Testura.Android.Device.Ui.Nodes.Data;
-using Testura.Android.PageObjectCreator.Models;
 using Testura.Android.PageObjectCreator.Util.Extensions;
 
 namespace Testura.Android.PageObjectCreator.Services

--- a/src/Testura.Android.PageObjectCreator/Services/ScreenService.cs
+++ b/src/Testura.Android.PageObjectCreator/Services/ScreenService.cs
@@ -22,14 +22,28 @@ namespace Testura.Android.PageObjectCreator.Services
         /// <param name="point">Points to check</param>
         /// <param name="dump">the xml dump</param>
         /// <returns>All intersected android elements</returns>
-        public IList<Node> GetNodes(Point point, string dump)
+        public IList<Node> GetNodes(Point point, Node node)
         {
-            var nodes = _dumpService.ParseDump(dump);
-            var matchingElements = nodes.Where(n => n.PointInsideBounds(point)).ToList();
+            var nodes = new List<Node>();
+             FindNode(point, node, nodes);
 
-            matchingElements.Sort((ae1, ae2) => ae1.Area().CompareTo(ae2.Area()));
+            nodes.Sort((ae1, ae2) => ae1.Area().CompareTo(ae2.Area()));
 
-            return matchingElements;
+            return nodes;
+        }
+
+        private void FindNode(Point point, Node node, IList<Node> foundNodes)
+        {
+            if (node.PointInsideBounds(point))
+            {
+                foundNodes.Add(node);
+            }
+
+            foreach (var nodeChild in node.Children)
+            {
+                FindNode(point, nodeChild, foundNodes);
+            }
+
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator/Services/ScreenService.cs
+++ b/src/Testura.Android.PageObjectCreator/Services/ScreenService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
 using Testura.Android.Device.Ui.Nodes.Data;
 using Testura.Android.PageObjectCreator.Util.Extensions;
@@ -7,41 +8,17 @@ namespace Testura.Android.PageObjectCreator.Services
 {
     public class ScreenService : IScreenService
     {
-        private readonly IDumpService _dumpService;
-
-        public ScreenService(IDumpService dumpService)
-        {
-            _dumpService = dumpService;
-        }
-
         /// <summary>
         /// Get all elements that intersect with a point on the screen
         /// </summary>
         /// <param name="point">Points to check</param>
-        /// <param name="dump">the xml dump</param>
+        /// <param name="nodes">All nodes on the dumped screen</param>
         /// <returns>All intersected android elements</returns>
-        public IList<Node> GetNodes(Point point, Node node)
+        public IList<Node> GetNodes(Point point, IList<Node> nodes)
         {
-            var nodes = new List<Node>();
-             FindNode(point, node, nodes);
-
-            nodes.Sort((ae1, ae2) => ae1.Area().CompareTo(ae2.Area()));
-
-            return nodes;
-        }
-
-        private void FindNode(Point point, Node node, IList<Node> foundNodes)
-        {
-            if (node.PointInsideBounds(point))
-            {
-                foundNodes.Add(node);
-            }
-
-            foreach (var nodeChild in node.Children)
-            {
-                FindNode(point, nodeChild, foundNodes);
-            }
-
+            var foundNodes = nodes.Where(n => n.IsPointInsideBounds(point)).ToList();
+            foundNodes.Sort((ae1, ae2) => ae1.Area().CompareTo(ae2.Area()));
+            return foundNodes;
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator/Services/UniqueWithFinderService.cs
+++ b/src/Testura.Android.PageObjectCreator/Services/UniqueWithFinderService.cs
@@ -8,7 +8,7 @@ using Testura.Android.Util;
 
 namespace Testura.Android.PageObjectCreator.Services
 {
-    public class UniqueWithFinderService : IAutoSelectedWithFinderService
+    public class UniqueWithFinderService : IUniqueWithFinderService
     {
         private readonly IList<AttributeTags> _attributesPriority;
 
@@ -43,7 +43,7 @@ namespace Testura.Android.PageObjectCreator.Services
 
                 if (CheckAttribute(selectedNode, properties, allNode))
                 {
-                    return new AutoSelectedWith { Withs = new List<AttributeTags>(combination) };
+                    return new AutoSelectedWith { Withs = new List<AttributeTags>(combination), Node = selectedNode };
                 }
             }
 

--- a/src/Testura.Android.PageObjectCreator/Services/UniqueWithFinderService.cs
+++ b/src/Testura.Android.PageObjectCreator/Services/UniqueWithFinderService.cs
@@ -8,11 +8,11 @@ using Testura.Android.Util;
 
 namespace Testura.Android.PageObjectCreator.Services
 {
-    public class OptimalWithService : IOptimalWithService
+    public class UniqueWithFinderService : IAutoSelectedWithFinderService
     {
         private readonly IList<AttributeTags> _attributesPriority;
 
-        public OptimalWithService()
+        public UniqueWithFinderService()
         {
             _attributesPriority = new List<AttributeTags>
             {
@@ -24,9 +24,11 @@ namespace Testura.Android.PageObjectCreator.Services
             };
         }
 
-        public OptimalWith GetOptimalWith(Node selectedNode, IList<Node> allNode)
+        public AutoSelectedWith GetUniqueWiths(Node selectedNode, IList<Node> allNode)
         {
-            var combinations = ItemCombinations(_attributesPriority, 1);
+            var combinations = GetAllCombinations(_attributesPriority);
+
+            // We can not use only text or index.
             combinations.Remove(combinations.FirstOrDefault(c => c.Count == 1 && c.First() == AttributeTags.Text));
             combinations.Remove(combinations.FirstOrDefault(c => c.Count == 1 && c.First() == AttributeTags.Index));
 
@@ -41,16 +43,16 @@ namespace Testura.Android.PageObjectCreator.Services
 
                 if (CheckAttribute(selectedNode, properties, allNode))
                 {
-                    return new OptimalWith {Withs = new List<AttributeTags>(combination)};
+                    return new AutoSelectedWith { Withs = new List<AttributeTags>(combination) };
                 }
             }
 
             if (selectedNode.Parent != null)
             {
-                var optimalParen = GetOptimalWith(selectedNode.Parent, allNode);
-                var thisOptimalWith = GetOptimalWith(selectedNode, selectedNode.Parent.Children);
-                thisOptimalWith.Parent = optimalParen;
-                return thisOptimalWith;
+                var uniqueParent = GetUniqueWiths(selectedNode.Parent, allNode);
+                var currentNodeUniqueWiths = GetUniqueWiths(selectedNode, selectedNode.Parent.Children);
+                currentNodeUniqueWiths.Parent = uniqueParent;
+                return currentNodeUniqueWiths;
             }
 
             throw new Exception("Failed to find any unique withs");
@@ -93,7 +95,7 @@ namespace Testura.Android.PageObjectCreator.Services
             return true;
         }
 
-        private IList<IList<T>> ItemCombinations<T>(IList<T> inputList, int minimumItems = 1)
+        private IList<IList<T>> GetAllCombinations<T>(IList<T> inputList, int minimumItems = 1)
         {
             var nonEmptyCombinations = (int)Math.Pow(2, inputList.Count) - 1;
             var listOfLists = new List<IList<T>>(nonEmptyCombinations + 1);

--- a/src/Testura.Android.PageObjectCreator/Testura.Android.PageObjectCreator.csproj
+++ b/src/Testura.Android.PageObjectCreator/Testura.Android.PageObjectCreator.csproj
@@ -104,6 +104,9 @@
     <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Reflection.Metadata.1.2.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MahApps.Metro.1.4.3\lib\net45\System.Windows.Interactivity.dll</HintPath>
       <Private>True</Private>

--- a/src/Testura.Android.PageObjectCreator/Testura.Android.PageObjectCreator.csproj
+++ b/src/Testura.Android.PageObjectCreator/Testura.Android.PageObjectCreator.csproj
@@ -117,11 +117,11 @@
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
-    <Reference Include="Testura.Android, Version=0.8.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Testura.Android.0.8.2\lib\net452\Testura.Android.dll</HintPath>
+    <Reference Include="Testura.Android, Version=0.9.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Testura.Android.0.9.2\lib\net452\Testura.Android.dll</HintPath>
     </Reference>
-    <Reference Include="Testura.Code, Version=0.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Testura.Code.0.4.0\lib\net452\Testura.Code.dll</HintPath>
+    <Reference Include="Testura.Code, Version=0.5.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Testura.Code.0.5.2\lib\net452\Testura.Code.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
@@ -158,13 +158,16 @@
     <Compile Include="Models\Messages\StoppedDumpScreenMessage.cs" />
     <Compile Include="Models\Messages\ShowNodeDetailsMessage.cs" />
     <Compile Include="Models\Messages\UiObjectInfoRemovedMessage.cs" />
+    <Compile Include="Models\NodeTreeItem.cs" />
     <Compile Include="Models\OptimalWith.cs" />
     <Compile Include="Models\PageObject.cs" />
     <Compile Include="Models\UiObjectInfo.cs" />
     <Compile Include="Models\Messages\AddUiObjectInfoMessage.cs" />
     <Compile Include="Models\Messages\DumpMessage.cs" />
+    <Compile Include="Services\CodeService.cs" />
     <Compile Include="Services\DeviceService.cs" />
     <Compile Include="Services\DialogService.cs" />
+    <Compile Include="Services\ICodeService.cs" />
     <Compile Include="Services\IDialogService.cs" />
     <Compile Include="Services\DumpService.cs" />
     <Compile Include="Services\FileService.cs" />
@@ -393,8 +396,8 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Fody.1.29.2\build\dotnet\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Fody.1.29.2\build\dotnet\Fody.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Testura.Android.0.8.2\build\testura.android.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Testura.Android.0.8.2\build\testura.android.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Testura.Android.0.9.2\build\testura.android.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Testura.Android.0.9.2\build\testura.android.targets'))" />
   </Target>
   <Import Project="..\..\packages\Fody.1.29.2\build\dotnet\Fody.targets" Condition="Exists('..\..\packages\Fody.1.29.2\build\dotnet\Fody.targets')" />
-  <Import Project="..\..\packages\Testura.Android.0.8.2\build\testura.android.targets" Condition="Exists('..\..\packages\Testura.Android.0.8.2\build\testura.android.targets')" />
+  <Import Project="..\..\packages\Testura.Android.0.9.2\build\testura.android.targets" Condition="Exists('..\..\packages\Testura.Android.0.9.2\build\testura.android.targets')" />
 </Project>

--- a/src/Testura.Android.PageObjectCreator/Testura.Android.PageObjectCreator.csproj
+++ b/src/Testura.Android.PageObjectCreator/Testura.Android.PageObjectCreator.csproj
@@ -158,6 +158,7 @@
     <Compile Include="Models\Messages\StoppedDumpScreenMessage.cs" />
     <Compile Include="Models\Messages\ShowNodeDetailsMessage.cs" />
     <Compile Include="Models\Messages\UiObjectInfoRemovedMessage.cs" />
+    <Compile Include="Models\OptimalWith.cs" />
     <Compile Include="Models\PageObject.cs" />
     <Compile Include="Models\UiObjectInfo.cs" />
     <Compile Include="Models\Messages\AddUiObjectInfoMessage.cs" />
@@ -170,7 +171,9 @@
     <Compile Include="Services\IDeviceService.cs" />
     <Compile Include="Services\IDumpService.cs" />
     <Compile Include="Services\IFileService.cs" />
+    <Compile Include="Services\IOptimalWithService.cs" />
     <Compile Include="Services\IScreenService.cs" />
+    <Compile Include="Services\OptimalWithService.cs" />
     <Compile Include="Services\ScreenService.cs" />
     <Compile Include="Util\Behaviors\AvalonEditBehavior.cs" />
     <Compile Include="Util\Converters\BooleanToVisibilityInvertedConverter.cs" />

--- a/src/Testura.Android.PageObjectCreator/Testura.Android.PageObjectCreator.csproj
+++ b/src/Testura.Android.PageObjectCreator/Testura.Android.PageObjectCreator.csproj
@@ -138,6 +138,9 @@
     <Compile Include="Dialogs\AboutDialog.xaml.cs">
       <DependentUpon>AboutDialog.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Dialogs\ClearDialog.xaml.cs">
+      <DependentUpon>ClearDialog.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Dialogs\ErrorDialog.xaml.cs">
       <DependentUpon>ErrorDialog.xaml</DependentUpon>
     </Compile>
@@ -177,7 +180,7 @@
     <Compile Include="Services\IDeviceService.cs" />
     <Compile Include="Services\IDumpService.cs" />
     <Compile Include="Services\IFileService.cs" />
-    <Compile Include="Services\IAutoSelectedWithFinderService.cs" />
+    <Compile Include="Services\IUniqueWithFinderService.cs" />
     <Compile Include="Services\IScreenService.cs" />
     <Compile Include="Services\UniqueWithFinderService.cs" />
     <Compile Include="Services\ScreenService.cs" />
@@ -216,6 +219,10 @@
       <DependentUpon>HierarchyView.xaml</DependentUpon>
     </Compile>
     <Page Include="Dialogs\AboutDialog.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Dialogs\ClearDialog.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/Testura.Android.PageObjectCreator/Testura.Android.PageObjectCreator.csproj
+++ b/src/Testura.Android.PageObjectCreator/Testura.Android.PageObjectCreator.csproj
@@ -162,7 +162,7 @@
     <Compile Include="Models\Messages\ShowNodeDetailsMessage.cs" />
     <Compile Include="Models\Messages\UiObjectInfoRemovedMessage.cs" />
     <Compile Include="Models\NodeTreeItem.cs" />
-    <Compile Include="Models\OptimalWith.cs" />
+    <Compile Include="Models\AutoSelectedWith.cs" />
     <Compile Include="Models\PageObject.cs" />
     <Compile Include="Models\UiObjectInfo.cs" />
     <Compile Include="Models\Messages\AddUiObjectInfoMessage.cs" />
@@ -177,9 +177,9 @@
     <Compile Include="Services\IDeviceService.cs" />
     <Compile Include="Services\IDumpService.cs" />
     <Compile Include="Services\IFileService.cs" />
-    <Compile Include="Services\IOptimalWithService.cs" />
+    <Compile Include="Services\IAutoSelectedWithFinderService.cs" />
     <Compile Include="Services\IScreenService.cs" />
-    <Compile Include="Services\OptimalWithService.cs" />
+    <Compile Include="Services\UniqueWithFinderService.cs" />
     <Compile Include="Services\ScreenService.cs" />
     <Compile Include="Util\Behaviors\AvalonEditBehavior.cs" />
     <Compile Include="Util\Converters\BooleanToVisibilityInvertedConverter.cs" />

--- a/src/Testura.Android.PageObjectCreator/Util/Converters/NodeToHierarchyTextConverter.cs
+++ b/src/Testura.Android.PageObjectCreator/Util/Converters/NodeToHierarchyTextConverter.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Windows.Data;
 using Testura.Android.Device.Ui.Nodes.Data;
+using Testura.Android.PageObjectCreator.Models;
 
 namespace Testura.Android.PageObjectCreator.Util.Converters
 {
@@ -9,7 +10,7 @@ namespace Testura.Android.PageObjectCreator.Util.Converters
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            var node = (Node)value;
+            var node = ((NodeTreeItem)value).Node;
 
             if (!string.IsNullOrEmpty(node.Text))
             {

--- a/src/Testura.Android.PageObjectCreator/Util/Extensions/NodeExtensions.cs
+++ b/src/Testura.Android.PageObjectCreator/Util/Extensions/NodeExtensions.cs
@@ -34,5 +34,27 @@ namespace Testura.Android.PageObjectCreator.Util.Extensions
             var elementBouds = node.GetNodeBounds();
             return (elementBouds[1].X - elementBouds[0].X) * (elementBouds[1].Y - elementBouds[0].Y);
         }
+
+
+        /// <summary>
+        /// Get current node and all children as a list
+        /// </summary>
+        /// <returns>Current node and all children as a list</returns>
+        public static IList<Node> GetAsList(this Node node)
+        {
+            var nodes = new List<Node>();
+            void GetNodes(Node currentNode)
+            {
+                nodes.Add(currentNode);
+
+                foreach (var child in currentNode.Children)
+                {
+                    GetNodes(child);
+                }
+            }
+
+            GetNodes(node);
+            return nodes;
+        }
     }
 }

--- a/src/Testura.Android.PageObjectCreator/Util/Extensions/NodeExtensions.cs
+++ b/src/Testura.Android.PageObjectCreator/Util/Extensions/NodeExtensions.cs
@@ -9,9 +9,10 @@ namespace Testura.Android.PageObjectCreator.Util.Extensions
         /// <summary>
         /// Check if a coordinate are inside node bounds
         /// </summary>
+        /// <param name="node">The node</param>
         /// <param name="coordinate">Coordinate to check</param>
         /// <returns>True if it are inside, otherwise false</returns>
-        public static bool PointInsideBounds(this Node node, Point coordinate)
+        public static bool IsPointInsideBounds(this Node node, Point coordinate)
         {
             var bounds = node.GetNodeBounds();
             if (coordinate.X >= bounds[0].X && coordinate.X <= bounds[1].X)
@@ -28,6 +29,7 @@ namespace Testura.Android.PageObjectCreator.Util.Extensions
         /// <summary>
         /// Get the area of the element
         /// </summary>
+        /// <param name="node">The node</param>
         /// <returns>The area of the element</returns>
         public static double Area(this Node node)
         {
@@ -35,12 +37,12 @@ namespace Testura.Android.PageObjectCreator.Util.Extensions
             return (elementBouds[1].X - elementBouds[0].X) * (elementBouds[1].Y - elementBouds[0].Y);
         }
 
-
         /// <summary>
         /// Get current node and all children as a list
         /// </summary>
+        /// <param name="node">The node</param>
         /// <returns>Current node and all children as a list</returns>
-        public static IList<Node> GetAsList(this Node node)
+        public static IList<Node> AllNodes(this Node node)
         {
             var nodes = new List<Node>();
             void GetNodes(Node currentNode)

--- a/src/Testura.Android.PageObjectCreator/ViewModels/HierarchyViewModel.cs
+++ b/src/Testura.Android.PageObjectCreator/ViewModels/HierarchyViewModel.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Linq;
 using GalaSoft.MvvmLight;
 using GalaSoft.MvvmLight.CommandWpf;
 using PropertyChanged;
@@ -6,38 +8,44 @@ using Testura.Android.Device.Ui.Nodes.Data;
 using Testura.Android.PageObjectCreator.Models;
 using Testura.Android.PageObjectCreator.Models.Messages;
 using Testura.Android.PageObjectCreator.Services;
+using Attribute = Testura.Android.PageObjectCreator.Models.Attribute;
 
 namespace Testura.Android.PageObjectCreator.ViewModels
 {
     [ImplementPropertyChanged]
     public class HierarchyViewModel : ViewModelBase
     {
-        private readonly IDumpService _dumpService;
-        private readonly IFileService _fileService;
-
-        public HierarchyViewModel(IDumpService dumpService, IFileService fileService)
+        public HierarchyViewModel()
         {
-            _dumpService = dumpService;
-            _fileService = fileService;
-            Nodes = new ObservableCollection<Node>();
+            Nodes = new ObservableCollection<NodeTreeItem>();
             Attributes = new ObservableCollection<Attribute>();
-            SelectedItemChangedCommand = new RelayCommand<Node>(SelectedItemChanged);
+            SelectedItemChangedCommand = new RelayCommand<NodeTreeItem>(SelectedItemChanged);
             AddCommand = new RelayCommand(AddNode, CanAddNode);
-            ExpandAllCommand = new RelayCommand(() => IsTreeExpanded = true);
-            ContractAllCommand = new RelayCommand(() => IsTreeExpanded = false);
+            ExpandAllCommand = new RelayCommand(() => ExpandAll(Nodes.First(), true));
+            ContractAllCommand = new RelayCommand(() => ExpandAll(Nodes.First(), false));
             MessengerInstance.Register<DumpMessage>(this, OnDump);
-            MessengerInstance.Register<ShowNodeDetailsMessage>(this, (message) => SelectedItemChanged(message.Node));
+            MessengerInstance.Register<ShowNodeDetailsMessage>(this, (message) => SelectedItemChanged(new NodeTreeItem(message.Node)));
         }
 
-        public Node SelectedNode { get; set; }
+        private void ExpandAll(NodeTreeItem node, bool expand)
+        {
+            node.IsExpanded = expand;
+
+            foreach (var nodeTreeItem in node.Children)
+            {
+                ExpandAll(nodeTreeItem, expand);
+            }
+        }
+
+        public NodeTreeItem SelectedNode { get; set; }
 
         public bool IsTreeExpanded { get; set; }
 
-        public ObservableCollection<Node> Nodes { get; set; }
+        public ObservableCollection<NodeTreeItem> Nodes { get; set; }
 
         public ObservableCollection<Attribute> Attributes { get; set; }
 
-        public RelayCommand<Node> SelectedItemChangedCommand { get; set; }
+        public RelayCommand<NodeTreeItem> SelectedItemChangedCommand { get; set; }
 
         public RelayCommand AddCommand { get; set; }
 
@@ -47,25 +55,50 @@ namespace Testura.Android.PageObjectCreator.ViewModels
 
         private void OnDump(DumpMessage message)
         {
-            var lines = _fileService.ReadAllLinesFromFile(message.DumpInfo.DumpPath);
-            var node = _dumpService.ParseDumpAsTree(string.Join(string.Empty, lines));
-            Nodes = new ObservableCollection<Node> { node };
+            Nodes = new ObservableCollection<NodeTreeItem> { new NodeTreeItem(message.Node) };
         }
 
-        private void SelectedItemChanged(Node selectNode)
+        private void SelectedItemChanged(NodeTreeItem selectNode)
         {
-            SelectedNode = selectNode;
-            MessengerInstance.Send(new SelectedHierarchyNodeMesssage { SelectedNode = selectNode });
+            if (selectNode == null)
+            {
+                return;
+            }
+
+            SelectedNode = FindNode(Nodes.First(), selectNode.Node);
+            MessengerInstance.Send(new SelectedHierarchyNodeMesssage { SelectedNode = SelectedNode.Node });
             Attributes.Clear();
-            foreach (var xAttribute in SelectedNode.Element.Attributes())
+            foreach (var xAttribute in SelectedNode.Node.Element.Attributes())
             {
                 Attributes.Add(new Attribute(xAttribute.Name.LocalName, xAttribute.Value));
             }
+
+            SelectedNode.IsSelected = true;
+            ExpandAll(Nodes.First(), true);
+        }
+
+        private NodeTreeItem FindNode(NodeTreeItem node, Node wantedNode)
+        {
+            if (node.Node == wantedNode)
+            {
+                return node;
+            }
+
+            foreach (var nodeTreeItem in node.Children)
+            {
+                var foundNode = FindNode(nodeTreeItem, wantedNode);
+                if (foundNode != null)
+                {
+                    return foundNode;
+                }
+            }
+
+            return null;
         }
 
         private void AddNode()
         {
-            MessengerInstance.Send(new AddNodeMessage { Node = SelectedNode });
+            MessengerInstance.Send(new AddNodeMessage { Node = SelectedNode.Node });
         }
 
         private bool CanAddNode()

--- a/src/Testura.Android.PageObjectCreator/ViewModels/HierarchyViewModel.cs
+++ b/src/Testura.Android.PageObjectCreator/ViewModels/HierarchyViewModel.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Linq;
 using GalaSoft.MvvmLight;
 using GalaSoft.MvvmLight.CommandWpf;
@@ -7,7 +6,6 @@ using PropertyChanged;
 using Testura.Android.Device.Ui.Nodes.Data;
 using Testura.Android.PageObjectCreator.Models;
 using Testura.Android.PageObjectCreator.Models.Messages;
-using Testura.Android.PageObjectCreator.Services;
 using Attribute = Testura.Android.PageObjectCreator.Models.Attribute;
 
 namespace Testura.Android.PageObjectCreator.ViewModels
@@ -21,20 +19,10 @@ namespace Testura.Android.PageObjectCreator.ViewModels
             Attributes = new ObservableCollection<Attribute>();
             SelectedItemChangedCommand = new RelayCommand<NodeTreeItem>(SelectedItemChanged);
             AddCommand = new RelayCommand(AddNode, CanAddNode);
-            ExpandAllCommand = new RelayCommand(() => ExpandAll(Nodes.First(), true));
-            ContractAllCommand = new RelayCommand(() => ExpandAll(Nodes.First(), false));
+            ExpandAllCommand = new RelayCommand(() => ExpandAllNodes(Nodes.First(), true));
+            ContractAllCommand = new RelayCommand(() => ExpandAllNodes(Nodes.First(), false));
             MessengerInstance.Register<DumpMessage>(this, OnDump);
             MessengerInstance.Register<ShowNodeDetailsMessage>(this, (message) => SelectedItemChanged(new NodeTreeItem(message.Node)));
-        }
-
-        private void ExpandAll(NodeTreeItem node, bool expand)
-        {
-            node.IsExpanded = expand;
-
-            foreach (var nodeTreeItem in node.Children)
-            {
-                ExpandAll(nodeTreeItem, expand);
-            }
         }
 
         public NodeTreeItem SelectedNode { get; set; }
@@ -55,7 +43,7 @@ namespace Testura.Android.PageObjectCreator.ViewModels
 
         private void OnDump(DumpMessage message)
         {
-            Nodes = new ObservableCollection<NodeTreeItem> { new NodeTreeItem(message.Node) };
+            Nodes = new ObservableCollection<NodeTreeItem> { new NodeTreeItem(message.TopNode) };
         }
 
         private void SelectedItemChanged(NodeTreeItem selectNode)
@@ -74,7 +62,17 @@ namespace Testura.Android.PageObjectCreator.ViewModels
             }
 
             SelectedNode.IsSelected = true;
-            ExpandAll(Nodes.First(), true);
+            ExpandAllNodes(Nodes.First(), true);
+        }
+
+        private void ExpandAllNodes(NodeTreeItem node, bool expand)
+        {
+            node.IsExpanded = expand;
+
+            foreach (var nodeTreeItem in node.Children)
+            {
+                ExpandAllNodes(nodeTreeItem, expand);
+            }
         }
 
         private NodeTreeItem FindNode(NodeTreeItem node, Node wantedNode)

--- a/src/Testura.Android.PageObjectCreator/ViewModels/OperationViewModel.cs
+++ b/src/Testura.Android.PageObjectCreator/ViewModels/OperationViewModel.cs
@@ -44,7 +44,7 @@ namespace Testura.Android.PageObjectCreator.ViewModels
                 var dumpInformation = await _dumpService.DumpScreenAsync(_serial);
                 var lines = _fileService.ReadAllLinesFromFile(dumpInformation.DumpPath);
                 var node = _dumpService.ParseDumpAsTree(string.Join(string.Empty, lines));
-                MessengerInstance.Send(new DumpMessage { DumpInfo = dumpInformation, Node = node });
+                MessengerInstance.Send(new DumpMessage { DumpInfo = dumpInformation, TopNode = node });
                 IsGoToActivityEnabled = true;
             }
             catch (Exception)

--- a/src/Testura.Android.PageObjectCreator/ViewModels/PageObjectViewModel.cs
+++ b/src/Testura.Android.PageObjectCreator/ViewModels/PageObjectViewModel.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using GalaSoft.MvvmLight;
 using GalaSoft.MvvmLight.CommandWpf;
 using PropertyChanged;
@@ -14,12 +13,11 @@ namespace Testura.Android.PageObjectCreator.ViewModels
     [ImplementPropertyChanged]
     public class PageObjectViewModel : ViewModelBase
     {
-        private IList<Node> _nodes;
         private readonly IDialogService _dialogService;
+        private Node _topNode;
 
         public PageObjectViewModel(IDialogService dialogService)
         {
-            _nodes = new List<Node>();
             _dialogService = dialogService;
             MessengerInstance.Register<DumpMessage>(this, OnDump);
             MessengerInstance.Register<AddUiObjectInfoMessage>(this, OnAddUiObjectInfo);
@@ -48,12 +46,12 @@ namespace Testura.Android.PageObjectCreator.ViewModels
         {
             PageObject.Activity = message.DumpInfo.Activity;
             PageObject.Package = message.DumpInfo.Package;
-            _nodes = message.Node.GetAsList();
+            _topNode = message.TopNode;
         }
 
         private void EditWiths(UiObjectInfo obj)
         {
-            _dialogService.ShowWithDialog(obj, _nodes);
+            _dialogService.ShowWithDialog(obj, _topNode.AllNodes());
             SendPageObjectChanged();
         }
 

--- a/src/Testura.Android.PageObjectCreator/ViewModels/PageObjectViewModel.cs
+++ b/src/Testura.Android.PageObjectCreator/ViewModels/PageObjectViewModel.cs
@@ -1,20 +1,25 @@
-﻿using System.ComponentModel;
+﻿using System.Collections.Generic;
+using System.ComponentModel;
 using GalaSoft.MvvmLight;
 using GalaSoft.MvvmLight.CommandWpf;
 using PropertyChanged;
+using Testura.Android.Device.Ui.Nodes.Data;
 using Testura.Android.PageObjectCreator.Models;
 using Testura.Android.PageObjectCreator.Models.Messages;
 using Testura.Android.PageObjectCreator.Services;
+using Testura.Android.PageObjectCreator.Util.Extensions;
 
 namespace Testura.Android.PageObjectCreator.ViewModels
 {
     [ImplementPropertyChanged]
     public class PageObjectViewModel : ViewModelBase
     {
+        private IList<Node> _nodes;
         private readonly IDialogService _dialogService;
 
         public PageObjectViewModel(IDialogService dialogService)
         {
+            _nodes = new List<Node>();
             _dialogService = dialogService;
             MessengerInstance.Register<DumpMessage>(this, OnDump);
             MessengerInstance.Register<AddUiObjectInfoMessage>(this, OnAddUiObjectInfo);
@@ -43,11 +48,12 @@ namespace Testura.Android.PageObjectCreator.ViewModels
         {
             PageObject.Activity = message.DumpInfo.Activity;
             PageObject.Package = message.DumpInfo.Package;
+            _nodes = message.Node.GetAsList();
         }
 
         private void EditWiths(UiObjectInfo obj)
         {
-            _dialogService.ShowWithDialog(obj);
+            _dialogService.ShowWithDialog(obj, _nodes);
             SendPageObjectChanged();
         }
 

--- a/src/Testura.Android.PageObjectCreator/ViewModels/PageObjectViewModel.cs
+++ b/src/Testura.Android.PageObjectCreator/ViewModels/PageObjectViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Linq;
 using GalaSoft.MvvmLight;
 using GalaSoft.MvvmLight.CommandWpf;
 using PropertyChanged;
@@ -21,6 +22,7 @@ namespace Testura.Android.PageObjectCreator.ViewModels
             _dialogService = dialogService;
             MessengerInstance.Register<DumpMessage>(this, OnDump);
             MessengerInstance.Register<AddUiObjectInfoMessage>(this, OnAddUiObjectInfo);
+            MessengerInstance.Register<StartedDumpScreenMessage>(this, OnStartDumpScreen);
             EditWithsCommand = new RelayCommand<UiObjectInfo>(EditWiths);
             UiInfoChangedCommand = new RelayCommand(SendPageObjectChanged);
             DeleteUiObjectInfoCommand = new RelayCommand<UiObjectInfo>(DeleteUiObjectInfo);
@@ -47,6 +49,17 @@ namespace Testura.Android.PageObjectCreator.ViewModels
             PageObject.Activity = message.DumpInfo.Activity;
             PageObject.Package = message.DumpInfo.Package;
             _topNode = message.TopNode;
+        }
+
+        private void OnStartDumpScreen(StartedDumpScreenMessage obj)
+        {
+            if (PageObject.UiObjectInfos.Any())
+            {
+                if (_dialogService.ShowClearUiObjectsDialog())
+                {
+                    PageObject.UiObjectInfos.Clear();
+                }
+            }
         }
 
         private void EditWiths(UiObjectInfo obj)

--- a/src/Testura.Android.PageObjectCreator/ViewModels/ScreenViewModel.cs
+++ b/src/Testura.Android.PageObjectCreator/ViewModels/ScreenViewModel.cs
@@ -18,6 +18,7 @@ namespace Testura.Android.PageObjectCreator.ViewModels
         private readonly IFileService _fileService;
         private readonly IScreenService _screenService;
         private readonly IDialogService _dialogService;
+        private Node _node;
 
         public ScreenViewModel(IFileService fileService, IScreenService screenService, IDialogService dialogService)
         {
@@ -47,8 +48,7 @@ namespace Testura.Android.PageObjectCreator.ViewModels
 
         public Node GetNodes(Point point, string dumpPath)
         {
-            var lines = _fileService.ReadAllLinesFromFile(dumpPath);
-            var nodes = _screenService.GetNodes(point, string.Join(string.Empty, lines));
+            var nodes = _screenService.GetNodes(point, _node);
             if (nodes.Any())
             {
                 var node = nodes.First();
@@ -101,6 +101,7 @@ namespace Testura.Android.PageObjectCreator.ViewModels
         {
             IsDumpingScreen = false;
             LoadImage?.Invoke(this, message.DumpInfo);
+            _node = message.Node;
         }
 
         private void OnStartedDumpingScreen(StartedDumpScreenMessage message)

--- a/src/Testura.Android.PageObjectCreator/ViewModels/ScreenViewModel.cs
+++ b/src/Testura.Android.PageObjectCreator/ViewModels/ScreenViewModel.cs
@@ -8,6 +8,7 @@ using Testura.Android.Device.Ui.Nodes.Data;
 using Testura.Android.PageObjectCreator.Models;
 using Testura.Android.PageObjectCreator.Models.Messages;
 using Testura.Android.PageObjectCreator.Services;
+using Testura.Android.PageObjectCreator.Util.Extensions;
 using Testura.Android.Util;
 
 namespace Testura.Android.PageObjectCreator.ViewModels
@@ -18,13 +19,15 @@ namespace Testura.Android.PageObjectCreator.ViewModels
         private readonly IFileService _fileService;
         private readonly IScreenService _screenService;
         private readonly IDialogService _dialogService;
+        private readonly IOptimalWithService _optimalWithService;
         private Node _node;
 
-        public ScreenViewModel(IFileService fileService, IScreenService screenService, IDialogService dialogService)
+        public ScreenViewModel(IFileService fileService, IScreenService screenService, IDialogService dialogService, IOptimalWithService optimalWithService)
         {
             _fileService = fileService;
             _screenService = screenService;
             _dialogService = dialogService;
+            _optimalWithService = optimalWithService;
             ShouldShowInfoMessage = true;
             MessengerInstance.Register<DumpMessage>(this, OnNewDump);
             MessengerInstance.Register<StartedDumpScreenMessage>(this, OnStartedDumpingScreen);
@@ -75,8 +78,10 @@ namespace Testura.Android.PageObjectCreator.ViewModels
                 {
                     Name = name,
                     Node = node,
-                    FindWith = new List<AttributeTags>()
+                    FindWith = new List<AttributeTags>(),
+                    Optimal = _optimalWithService.GetOptimalWith(node, _node.GetAsList())
                 };
+                uiNodeInfo.FindWithString = "Automatic";
                 MessengerInstance.Send(new AddUiObjectInfoMessage { UiNodeInfo = uiNodeInfo });
                 return true;
             }

--- a/src/Testura.Android.PageObjectCreator/ViewModels/ScreenViewModel.cs
+++ b/src/Testura.Android.PageObjectCreator/ViewModels/ScreenViewModel.cs
@@ -18,14 +18,14 @@ namespace Testura.Android.PageObjectCreator.ViewModels
     {
         private readonly IScreenService _screenService;
         private readonly IDialogService _dialogService;
-        private readonly IAutoSelectedWithFinderService _autoSelectedWithFinderService;
+        private readonly IUniqueWithFinderService _uniqueWithFinderService;
         private Node _topNode;
 
-        public ScreenViewModel(IScreenService screenService, IDialogService dialogService, IAutoSelectedWithFinderService autoSelectedWithFinderService)
+        public ScreenViewModel(IScreenService screenService, IDialogService dialogService, IUniqueWithFinderService uniqueWithFinderService)
         {
             _screenService = screenService;
             _dialogService = dialogService;
-            _autoSelectedWithFinderService = autoSelectedWithFinderService;
+            _uniqueWithFinderService = uniqueWithFinderService;
             ShouldShowInfoMessage = true;
             MessengerInstance.Register<DumpMessage>(this, OnNewDump);
             MessengerInstance.Register<StartedDumpScreenMessage>(this, OnStartedDumpingScreen);
@@ -77,7 +77,7 @@ namespace Testura.Android.PageObjectCreator.ViewModels
                     Name = name,
                     Node = node,
                     FindWith = new List<AttributeTags>(),
-                    AutoSelectedWith = _autoSelectedWithFinderService.GetUniqueWiths(node, _topNode.AllNodes()),
+                    AutoSelectedWith = _uniqueWithFinderService.GetUniqueWiths(node, _topNode.AllNodes()),
                     DisplayName = "Automatic"
                 };
                 MessengerInstance.Send(new AddUiObjectInfoMessage { UiNodeInfo = uiNodeInfo });

--- a/src/Testura.Android.PageObjectCreator/ViewModels/ViewModelLocator.cs
+++ b/src/Testura.Android.PageObjectCreator/ViewModels/ViewModelLocator.cs
@@ -1,4 +1,5 @@
 using GalaSoft.MvvmLight.Ioc;
+using Microsoft.CodeAnalysis;
 using Microsoft.Practices.ServiceLocation;
 using Testura.Android.PageObjectCreator.Services;
 using Testura.Android.PageObjectCreator.Util;
@@ -33,6 +34,7 @@ namespace Testura.Android.PageObjectCreator.ViewModels
             SimpleIoc.Default.Register<IFileService, FileService>();
             SimpleIoc.Default.Register<IScreenService, ScreenService>();
             SimpleIoc.Default.Register<ICodeService, CodeService>();
+            SimpleIoc.Default.Register<IOptimalWithService, OptimalWithService>();
         }
 
         public MainViewModel MainViewModel => ServiceLocator.Current.GetInstance<MainViewModel>();

--- a/src/Testura.Android.PageObjectCreator/ViewModels/ViewModelLocator.cs
+++ b/src/Testura.Android.PageObjectCreator/ViewModels/ViewModelLocator.cs
@@ -32,6 +32,7 @@ namespace Testura.Android.PageObjectCreator.ViewModels
             SimpleIoc.Default.Register<IDialogService, DialogService>();
             SimpleIoc.Default.Register<IFileService, FileService>();
             SimpleIoc.Default.Register<IScreenService, ScreenService>();
+            SimpleIoc.Default.Register<ICodeService, CodeService>();
         }
 
         public MainViewModel MainViewModel => ServiceLocator.Current.GetInstance<MainViewModel>();

--- a/src/Testura.Android.PageObjectCreator/ViewModels/ViewModelLocator.cs
+++ b/src/Testura.Android.PageObjectCreator/ViewModels/ViewModelLocator.cs
@@ -34,7 +34,7 @@ namespace Testura.Android.PageObjectCreator.ViewModels
             SimpleIoc.Default.Register<IFileService, FileService>();
             SimpleIoc.Default.Register<IScreenService, ScreenService>();
             SimpleIoc.Default.Register<ICodeService, CodeService>();
-            SimpleIoc.Default.Register<IAutoSelectedWithFinderService, UniqueWithFinderService>();
+            SimpleIoc.Default.Register<IUniqueWithFinderService, UniqueWithFinderService>();
         }
 
         public MainViewModel MainViewModel => ServiceLocator.Current.GetInstance<MainViewModel>();

--- a/src/Testura.Android.PageObjectCreator/ViewModels/ViewModelLocator.cs
+++ b/src/Testura.Android.PageObjectCreator/ViewModels/ViewModelLocator.cs
@@ -34,7 +34,7 @@ namespace Testura.Android.PageObjectCreator.ViewModels
             SimpleIoc.Default.Register<IFileService, FileService>();
             SimpleIoc.Default.Register<IScreenService, ScreenService>();
             SimpleIoc.Default.Register<ICodeService, CodeService>();
-            SimpleIoc.Default.Register<IOptimalWithService, OptimalWithService>();
+            SimpleIoc.Default.Register<IAutoSelectedWithFinderService, UniqueWithFinderService>();
         }
 
         public MainViewModel MainViewModel => ServiceLocator.Current.GetInstance<MainViewModel>();

--- a/src/Testura.Android.PageObjectCreator/ViewModels/WithViewModel.cs
+++ b/src/Testura.Android.PageObjectCreator/ViewModels/WithViewModel.cs
@@ -14,13 +14,13 @@ namespace Testura.Android.PageObjectCreator.ViewModels
     [ImplementPropertyChanged]
     public class WithViewModel
     {
+        private readonly IAutoSelectedWithFinderService _autoSelectedWithFinderService;
         private IList<Node> _allNodes;
-        private readonly IOptimalWithService _optimalWithService;
 
-        public WithViewModel(IOptimalWithService optimalWithService)
+        public WithViewModel(IAutoSelectedWithFinderService autoSelectedWithFinderService)
         {
             _allNodes = new List<Node>();
-            _optimalWithService = optimalWithService;
+            _autoSelectedWithFinderService = autoSelectedWithFinderService;
             NotUsedWiths = new ObservableCollection<AttributeTags>();
             UsedWiths = new ObservableCollection<AttributeTags>();
             AddCommand = new RelayCommand<AttributeTags>(AddWith);
@@ -54,7 +54,7 @@ namespace Testura.Android.PageObjectCreator.ViewModels
         {
             _allNodes = new List<Node>(allNodes);
             UiObjectInfo = uiObjectInfo;
-            UseUniqueWiths = uiObjectInfo.Optimal != null;
+            UseUniqueWiths = uiObjectInfo.AutoSelectedWith != null;
             NotUsedWiths.Clear();
             UsedWiths.Clear();
             LoadWiths();
@@ -131,14 +131,14 @@ namespace Testura.Android.PageObjectCreator.ViewModels
 
             if (UseUniqueWiths)
             {
-                UiObjectInfo.Optimal = _optimalWithService.GetOptimalWith(UiObjectInfo.Node, _allNodes);
+                UiObjectInfo.AutoSelectedWith = _autoSelectedWithFinderService.GetUniqueWiths(UiObjectInfo.Node, _allNodes);
             }
             else
             {
-                UiObjectInfo.Optimal = null;
+                UiObjectInfo.AutoSelectedWith = null;
             }
 
-            UiObjectInfo.FindWithString = UiObjectInfo.Optimal != null ? "Automatic" : string.Join(", ", UiObjectInfo.FindWith);
+            UiObjectInfo.UpdateDisplayName();
             Close();
         }
 

--- a/src/Testura.Android.PageObjectCreator/ViewModels/WithViewModel.cs
+++ b/src/Testura.Android.PageObjectCreator/ViewModels/WithViewModel.cs
@@ -14,13 +14,13 @@ namespace Testura.Android.PageObjectCreator.ViewModels
     [ImplementPropertyChanged]
     public class WithViewModel
     {
-        private readonly IAutoSelectedWithFinderService _autoSelectedWithFinderService;
+        private readonly IUniqueWithFinderService _uniqueWithFinderService;
         private IList<Node> _allNodes;
 
-        public WithViewModel(IAutoSelectedWithFinderService autoSelectedWithFinderService)
+        public WithViewModel(IUniqueWithFinderService uniqueWithFinderService)
         {
             _allNodes = new List<Node>();
-            _autoSelectedWithFinderService = autoSelectedWithFinderService;
+            _uniqueWithFinderService = uniqueWithFinderService;
             NotUsedWiths = new ObservableCollection<AttributeTags>();
             UsedWiths = new ObservableCollection<AttributeTags>();
             AddCommand = new RelayCommand<AttributeTags>(AddWith);
@@ -131,7 +131,7 @@ namespace Testura.Android.PageObjectCreator.ViewModels
 
             if (UseUniqueWiths)
             {
-                UiObjectInfo.AutoSelectedWith = _autoSelectedWithFinderService.GetUniqueWiths(UiObjectInfo.Node, _allNodes);
+                UiObjectInfo.AutoSelectedWith = _uniqueWithFinderService.GetUniqueWiths(UiObjectInfo.Node, _allNodes);
             }
             else
             {

--- a/src/Testura.Android.PageObjectCreator/Views/HierarchyView.xaml
+++ b/src/Testura.Android.PageObjectCreator/Views/HierarchyView.xaml
@@ -126,7 +126,7 @@
                Grid.Column="0" />
         <TreeView ItemsSource="{Binding DataContext.Nodes, ElementName=root}" Grid.Row="2" Margin="10, 0, 0, 0" x:Name="Nodes">
             <TreeView.Resources>
-                <HierarchicalDataTemplate DataType="{x:Type data:Node}" ItemsSource="{Binding Children}">
+                <HierarchicalDataTemplate DataType="{x:Type models:NodeTreeItem}" ItemsSource="{Binding Children}">
                     <TextBlock Text="{Binding Converter={StaticResource NodeToHierarchyTextConverter}}" />
                 </HierarchicalDataTemplate>
             </TreeView.Resources>
@@ -137,8 +137,21 @@
             </i:Interaction.Triggers>
             <TreeView.ItemContainerStyle>
                 <Style TargetType="TreeViewItem">
-                    <Setter Property="IsExpanded" Value="{Binding DataContext.IsTreeExpanded, ElementName=root}"/>
-                </Style>
+                    <Setter Property="IsExpanded"
+                        Value="{Binding IsExpanded, Mode=TwoWay}" />
+                    <Setter Property="IsSelected"
+                        Value="{Binding IsSelected, Mode=TwoWay}" />
+                    <Setter Property="FontWeight"
+                        Value="Normal" />
+                    <EventSetter Event="Selected" Handler="TreeViewSelectedItemChanged" />
+                    <Style.Triggers>
+                        <Trigger Property="IsSelected"
+                              Value="True">
+                            <Setter Property="FontWeight"
+                                    Value="Bold" />
+                        </Trigger>
+                    </Style.Triggers>
+                    </Style>
             </TreeView.ItemContainerStyle>
         </TreeView>
         <Label Content="Node details"

--- a/src/Testura.Android.PageObjectCreator/Views/HierarchyView.xaml.cs
+++ b/src/Testura.Android.PageObjectCreator/Views/HierarchyView.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Controls;
+﻿using System.Windows;
+using System.Windows.Controls;
 
 namespace Testura.Android.PageObjectCreator.Views
 {
@@ -10,6 +11,16 @@ namespace Testura.Android.PageObjectCreator.Views
         public HierarchyView()
         {
             InitializeComponent();
+        }
+
+        private void TreeViewSelectedItemChanged(object sender, RoutedEventArgs e)
+        {
+            TreeViewItem item = sender as TreeViewItem;
+            if (item != null)
+            {
+                item.BringIntoView();
+                e.Handled = true;
+            }
         }
     }
 }

--- a/src/Testura.Android.PageObjectCreator/Views/PageObjectView.xaml
+++ b/src/Testura.Android.PageObjectCreator/Views/PageObjectView.xaml
@@ -101,7 +101,7 @@
                                         Width="*"
                                         />
                     <DataGridTextColumn Header="Select with"
-                                        Binding="{Binding FindWithString}"
+                                        Binding="{Binding DisplayName}"
                                         Width="*"
                                         IsReadOnly="True"/>
                     <DataGridTemplateColumn Width="120">

--- a/src/Testura.Android.PageObjectCreator/Views/PageObjectView.xaml
+++ b/src/Testura.Android.PageObjectCreator/Views/PageObjectView.xaml
@@ -73,7 +73,7 @@
         </Grid>
         <StackPanel
                     Grid.Row="4">
-            <Label Content="Current elements"
+            <Label Content="UiObjects"
                    Foreground="White"
                    Background="{StaticResource WindowTitleColorBrush}"
                    Margin="10, 10, 10, 10" />

--- a/src/Testura.Android.PageObjectCreator/Views/ScreenView.xaml
+++ b/src/Testura.Android.PageObjectCreator/Views/ScreenView.xaml
@@ -20,7 +20,7 @@
                Grid.Row="0"
                Grid.Column="0" />
         <Label Grid.Row="1" HorizontalAlignment="Left" VerticalAlignment="Top" Content="Hover for information" Margin="24, 5, 5, 5" Foreground="White"
-               Background="{StaticResource WindowTitleColorBrush}" ToolTip="Left-click to add new UI object, Right-click to view node details (in hierarchy tab)">
+               Background="{StaticResource WindowTitleColorBrush}" ToolTip="Left-click to view node details (in hierarchy tab). Ctrl + Left-click to add UiObject">
             <Label.RenderTransform>
                 <RotateTransform Angle="90" />
             </Label.RenderTransform>

--- a/src/Testura.Android.PageObjectCreator/Views/ScreenView.xaml.cs
+++ b/src/Testura.Android.PageObjectCreator/Views/ScreenView.xaml.cs
@@ -99,15 +99,7 @@ namespace Testura.Android.PageObjectCreator.Views
 
             var node = MarkNode();
 
-            if (e.RightButton == MouseButtonState.Pressed && node != null)
-            {
-                DeviceCanvas.Children.Remove(_lastSelectedNodeRectangle);
-                _lastSelectedNodeRectangle = null;
-                _viewModel.ShowNodeDetails(node);
-                return;
-            }
-
-            if (e.LeftButton == MouseButtonState.Pressed && node != null)
+            if (e.LeftButton == MouseButtonState.Pressed && Keyboard.IsKeyDown(Key.LeftCtrl) && node != null)
             {
                 var rec = _lastSelectedNodeRectangle;
                 _lastSelectedNodeRectangle = null;
@@ -120,6 +112,16 @@ namespace Testura.Android.PageObjectCreator.Views
                 {
                     DeviceCanvas.Children.Remove(rec);
                 }
+
+                return;
+            }
+
+            if ((e.LeftButton == MouseButtonState.Pressed || e.RightButton == MouseButtonState.Pressed) && node != null)
+            {
+                DeviceCanvas.Children.Remove(_lastSelectedNodeRectangle);
+                _lastSelectedNodeRectangle = null;
+                _viewModel.ShowNodeDetails(node);
+                return;
             }
         }
 

--- a/src/Testura.Android.PageObjectCreator/packages.config
+++ b/src/Testura.Android.PageObjectCreator/packages.config
@@ -26,6 +26,6 @@
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net452" />
   <package id="System.Threading" version="4.0.0" targetFramework="net452" />
-  <package id="Testura.Android" version="0.8.2" targetFramework="net452" />
-  <package id="Testura.Code" version="0.4.0" targetFramework="net452" />
+  <package id="Testura.Android" version="0.9.2" targetFramework="net452" />
+  <package id="Testura.Code" version="0.5.2" targetFramework="net452" />
 </packages>

--- a/src/Testura.Android.PageObjectCreator/packages.config
+++ b/src/Testura.Android.PageObjectCreator/packages.config
@@ -26,6 +26,7 @@
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net452" />
   <package id="System.Threading" version="4.0.0" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.3.0" targetFramework="net452" />
   <package id="Testura.Android" version="0.9.2" targetFramework="net452" />
   <package id="Testura.Code" version="0.5.2" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
- Switched place on the hierarchy and page object tab 
- Change so simple left and right click only select the node. To add a node you need to ctrl + left click or click on the add button inside the hierarchy tab
- Improved the hiearchy tree so it's easier to see which node you have selected. It will also automatically select the correct tree item if you select a node in the screen view.
- Added new feature to automatically select unique withs (will look at bort attributes and parents)
- If you dump the screen and have existing UiObjects it will now ask if we should clear them. 
- Fixed expand and collapse
- Fixed window title 
